### PR TITLE
ランク戦見守り部屋の部屋名を固定名に変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -829,8 +829,9 @@ async def on_voice_state_update(member: discord.Member, before: discord.VoiceSta
         if not category:
             return
         try:
+            channel_name: str = "👀｜ランク戦見守り部屋" if after.channel.id == RANK_GAME_CHANNEL_ID else "".join(random.choices(string.ascii_letters + string.digits, k=5))
             new_channel: discord.VoiceChannel = await guild.create_voice_channel(
-                name="".join(random.choices(string.ascii_letters + string.digits, k=5)),
+                name=channel_name,
                 category=category,
                 user_limit=0,  # 0=制限なし
             )


### PR DESCRIPTION
## Summary
- ランク戦見守り部屋から作成されるVCの名前を、ランダムIDから「👀｜ランク戦見守り部屋」に変更
- 通常のVC作成（通話チャンネル）は従来通りランダム名を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)