### PR TITLE
on_ready再発火による起動時ランキングの過剰投稿を修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -448,9 +448,18 @@ async def create_ranking_embed() -> discord.Embed:
     return embed
 
 # --- イベント ---
+_startup_done: bool = False
+
 @bot.event
 async def on_ready() -> None:
+    global _startup_done
     print(f"Bot logged in as {bot.user}")
+
+    # on_readyは再接続のたびに発火するため、初回起動時のみ初期化処理を実行
+    if _startup_done:
+        print("--- Reconnected (skipping initial setup) ---")
+        return
+    _startup_done = True
 
     # Bot起動時に永続Viewを登録
     bot.add_view(DashboardView())
@@ -462,7 +471,8 @@ async def on_ready() -> None:
         if ranking_embed:
             await channel.send("【起動時ランキング速報】", embed=ranking_embed)
 
-    check_ranks_periodically.start()
+    if not check_ranks_periodically.is_running():
+        check_ranks_periodically.start()
 
 # --- コマンド ---
 @bot.slash_command(name="register", description="あなたのRiot IDをボットに登録します。", guild_ids=[DISCORD_GUILD_ID])


### PR DESCRIPTION
## Summary
- Discordとの再接続時に`on_ready`が再発火し、起動時ランキング投稿と`check_ranks_periodically.start()`が何度も実行される問題を修正
- 初回起動時のみ初期化処理を行うガードフラグ`_startup_done`を追加
- `check_ranks_periodically.is_running()`で二重起動を防止

## 症状
Botが短時間にリーダーボードを何度も投稿する現象が発生。ログに下記が繰り返し記録されていた：
```
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected
Bot logged in as (β)ぱぶびゅ！bot#1887
--- Posting initial ranking on startup ---
```

## 原因
`on_ready`はDiscordとの接続が確立するたびに発火する（初回起動時だけではない）。一時的なネットワーク切断で再接続が起こるたびに、起動時ランキング投稿が繰り返されていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)