### PR TITLE
コントリビューションシステム導入（Phase 1 + Phase 3 段階リリース）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
 data/
+
+# --- web/ (Astro + Cloudflare) ---
+web/node_modules/
+web/dist/
+web/.astro/
+web/.wrangler/
+web/.dev.vars
+web/.env
+web/.env.*
+!web/.dev.vars.example
+
+# OS / editor
+.DS_Store
+*.swp
+*.log

--- a/main.py
+++ b/main.py
@@ -185,14 +185,22 @@ def level_from_xp(xp: int, coef: int = CONTRIBUTION_USER_LEVEL_COEF, exp: float 
     return max(1, int(raw_level))
 
 
-def add_contribution(discord_id: int, xp: int, vc_seconds: int, text_messages: int, last_text_at_iso: str | None = None) -> None:
-    """totals と monthly に同時加算。組分け済みであることは呼び出し側で保証する。"""
+def add_contribution(discord_id: int, xp: int, vc_seconds: int, text_messages: int, last_text_at_iso: str | None = None) -> tuple[int, int]:
+    """totals と monthly に同時加算。組分け済みであることは呼び出し側で保証する。
+
+    返り値: (old_level, new_level) - 加算前後の個人レベル。Lvアップ判定に使う。
+    """
     if xp == 0 and vc_seconds == 0 and text_messages == 0:
-        return
+        return (0, 0)
     now_iso: str = datetime.datetime.now(datetime.timezone.utc).isoformat()
     ym: str = current_year_month_jst()
     con: sqlite3.Connection = sqlite3.connect(DB_PATH)
     cur: sqlite3.Cursor = con.cursor()
+    # 加算前の累積XPを取得（Lvアップ判定用）
+    cur.execute("SELECT total_xp FROM contribution_totals WHERE discord_id = ?", (discord_id,))
+    row: tuple[int] | None = cur.fetchone()
+    old_xp: int = row[0] if row else 0
+    old_level: int = level_from_xp(old_xp)
     # totals
     cur.execute(
         """
@@ -221,6 +229,86 @@ def add_contribution(discord_id: int, xp: int, vc_seconds: int, text_messages: i
     )
     con.commit()
     con.close()
+    new_level: int = level_from_xp(old_xp + xp)
+    return (old_level, new_level)
+
+
+def get_user_house_id(discord_id: int) -> str | None:
+    """sorting_hat から所属寮IDを取得"""
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute("SELECT house_id FROM sorting_hat WHERE discord_id = ?", (discord_id,))
+    row: tuple[str] | None = cur.fetchone()
+    con.close()
+    return row[0] if row else None
+
+
+def get_house_channel_id(house_id: str, channel_type: str) -> int | None:
+    """house_channels から指定寮・チャンネル種別のIDを取得"""
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute(
+        "SELECT channel_id FROM house_channels WHERE house_id = ? AND channel_type = ?",
+        (house_id, channel_type),
+    )
+    row: tuple[int] | None = cur.fetchone()
+    con.close()
+    return row[0] if row else None
+
+
+async def notify_level_up(discord_id: int, old_level: int, new_level: int) -> None:
+    """所属寮の リーダーボード チャンネルに Lvアップ祝福を投稿する。
+    1Lv上昇でも 2Lv以上上昇でも一回だけ最終Lvを祝う（連続Lvアップは合算表現）。
+    """
+    if new_level <= old_level:
+        return
+    house_id: str | None = get_user_house_id(discord_id)
+    if house_id is None:
+        return
+    channel_id: int | None = get_house_channel_id(house_id, "leaderboard")
+    if channel_id is None:
+        return
+    channel: discord.abc.GuildChannel | None = bot.get_channel(channel_id)
+    if not isinstance(channel, discord.TextChannel):
+        return
+    house_info: tuple[str, str, str, str] | None = next((h for h in HOUSES if h[0] == house_id), None)
+    house_emoji: str = house_info[2] if house_info else "🏰"
+    house_name_jp: str = house_info[1] if house_info else "?"
+
+    # 次Lvまでの必要XP
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute("SELECT total_xp FROM contribution_totals WHERE discord_id = ?", (discord_id,))
+    row: tuple[int] | None = cur.fetchone()
+    con.close()
+    total_xp: int = row[0] if row else 0
+    next_required: int = required_xp_for_level(new_level + 1)
+    cur_required: int = required_xp_for_level(new_level)
+    remaining: int = max(0, next_required - total_xp)
+    in_lv: int = max(0, total_xp - cur_required)
+    span: int = max(1, next_required - cur_required)
+
+    title: str = "🎉 Lv UP!"
+    if new_level - old_level >= 2:
+        title = f"🎉🎉 {new_level - old_level}連Lv UP!"
+
+    embed: discord.Embed = discord.Embed(
+        title=title,
+        description=f"<@{discord_id}> さんが **Lv {new_level}** に到達しました！",
+        color=discord.Color.gold(),
+    )
+    embed.add_field(name="所属", value=f"{house_emoji} {house_name_jp}", inline=True)
+    embed.add_field(name="現在", value=f"Lv {new_level}", inline=True)
+    embed.add_field(name=f"次Lv {new_level + 1} まで", value=f"あと **{remaining:,} XP**（{in_lv:,}/{span:,}）", inline=False)
+    embed.set_footer(text="Webダッシュボード: https://pubview-dashboard.pages.dev/")
+    try:
+        await channel.send(
+            embed=embed,
+            # 個人メンションは embed の description 内に <@id> として含めて発火させる
+            allowed_mentions=discord.AllowedMentions(everyone=False, roles=False, users=[discord.Object(id=discord_id)]),
+        )
+    except Exception as e:
+        print(f"!!! notify_level_up: failed to send to channel {channel_id}: {e}")
 
 
 def vc_session_start(discord_id: int, channel_id: int) -> None:
@@ -236,32 +324,35 @@ def vc_session_start(discord_id: int, channel_id: int) -> None:
     con.close()
 
 
-def vc_session_end(discord_id: int) -> int:
-    """VC退出時に在室秒数を確定し、totals/monthly へ加算。在室秒数を返す。"""
+def vc_session_end(discord_id: int) -> tuple[int, int]:
+    """VC退出時に在室秒数を確定し、totals/monthly へ加算。
+
+    返り値: (old_level, new_level) - Lvアップ判定用。何も加算されなかった場合は (0, 0)。
+    """
     con: sqlite3.Connection = sqlite3.connect(DB_PATH)
     cur: sqlite3.Cursor = con.cursor()
     cur.execute("SELECT joined_at FROM vc_sessions WHERE discord_id = ?", (discord_id,))
     row: tuple[str] | None = cur.fetchone()
     if not row:
         con.close()
-        return 0
+        return (0, 0)
     try:
         joined_at: datetime.datetime = datetime.datetime.fromisoformat(row[0])
     except ValueError:
         cur.execute("DELETE FROM vc_sessions WHERE discord_id = ?", (discord_id,))
         con.commit()
         con.close()
-        return 0
+        return (0, 0)
     now_utc: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
     seconds: int = max(0, int((now_utc - joined_at).total_seconds()))
     cur.execute("DELETE FROM vc_sessions WHERE discord_id = ?", (discord_id,))
     con.commit()
     con.close()
-    if seconds > 0:
-        # 分単位で切り捨て、端数秒は次回まわし（vc_secondsは秒で記録）
-        added_xp: int = (seconds // 60) * CONTRIBUTION_VC_PT_PER_MINUTE
-        add_contribution(discord_id, xp=added_xp, vc_seconds=seconds, text_messages=0)
-    return seconds
+    if seconds <= 0:
+        return (0, 0)
+    # 分単位で切り捨て、端数秒は次回まわし（vc_secondsは秒で記録）
+    added_xp: int = (seconds // 60) * CONTRIBUTION_VC_PT_PER_MINUTE
+    return add_contribution(discord_id, xp=added_xp, vc_seconds=seconds, text_messages=0)
 # -----------------------------
 
 # --- Botの初期設定 ---
@@ -1346,6 +1437,58 @@ async def remove_user_from_section(ctx: discord.ApplicationContext, user: discor
 
 
 # --- デバッグ用コマンド ---
+@bot.slash_command(
+    name="setup_dev_channel",
+    description="開発者用のテストチャンネルを作成します（実行者と Bot のみ閲覧可）。",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def setup_dev_channel(
+    ctx: discord.ApplicationContext,
+    channel_name: discord.Option(str, "作成するチャンネル名", default="🧪｜bot-test"),  # type: ignore[valid-type]
+) -> None:
+    """テスト用のプライベートチャンネルを作成する。
+
+    権限: @everyone view denied / 実行者 view+send allow / Bot view+send+manage allow
+    既存があればそのまま流用してIDだけ返す（idempotent）。
+    """
+    await ctx.defer(ephemeral=True)
+    guild: discord.Guild | None = ctx.guild
+    if guild is None:
+        await ctx.respond("ギルド情報が取得できませんでした。", ephemeral=True)
+        return
+
+    existing: discord.TextChannel | None = discord.utils.get(guild.text_channels, name=channel_name)
+    if existing is not None:
+        await ctx.respond(
+            f"既に同名のチャンネルが存在します: {existing.mention} (ID: `{existing.id}`)",
+            ephemeral=True,
+        )
+        return
+
+    me: discord.Member = guild.me if guild.me is not None else await guild.fetch_member(bot.user.id)
+    author: discord.User | discord.Member = ctx.author
+    overwrites: dict[discord.Role | discord.Member, discord.PermissionOverwrite] = {
+        guild.default_role: discord.PermissionOverwrite(view_channel=False),
+        author:             discord.PermissionOverwrite(view_channel=True, send_messages=True, read_message_history=True),
+        me:                 discord.PermissionOverwrite(view_channel=True, send_messages=True, manage_messages=True, manage_channels=True),
+    }
+    try:
+        created: discord.TextChannel = await guild.create_text_channel(
+            name=channel_name,
+            overwrites=overwrites,
+            reason=f"setup_dev_channel by {author}",
+        )
+    except Exception as e:
+        await ctx.respond(f"作成失敗: `{e}`", ephemeral=True)
+        return
+    await ctx.respond(
+        f"✅ テストチャンネル {created.mention} を作成しました（ID: `{created.id}`）。\n"
+        "あなたと Bot のみ閲覧可能です。他の管理者を追加したい場合は手動で permission を編集してください。",
+        ephemeral=True,
+    )
+
+
 @bot.slash_command(name="debug_check_ranks_periodically", description="定期的なランクチェックを手動で実行します。（デバッグ用）", guild_ids=[DISCORD_GUILD_ID])
 @discord.default_permissions(administrator=True)
 async def debug_check_ranks_periodically(ctx: discord.ApplicationContext) -> None:
@@ -1401,6 +1544,34 @@ async def debug_modify_rank(ctx: discord.ApplicationContext, user: discord.Membe
 
     except Exception as e:
         await ctx.respond(f"処理中にエラーが発生しました: {e}")
+
+
+@bot.slash_command(
+    name="debug_grant_xp",
+    description="指定ユーザーにXPを付与してLvアップを強制発火させます。（デバッグ用）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def debug_grant_xp(
+    ctx: discord.ApplicationContext,
+    user: discord.Member,
+    amount: int,
+) -> None:
+    """組分け済みユーザーに任意のXPを加算する。Lvが上がれば祝福通知も発火する。"""
+    await ctx.defer(ephemeral=True)
+    if not is_sorted(user.id):
+        await ctx.respond(f"{user.display_name} はまだ組分け帽子を被っていません。", ephemeral=True)
+        return
+    if amount == 0:
+        await ctx.respond("amount は 0 以外を指定してください。", ephemeral=True)
+        return
+    old_level, new_level = add_contribution(user.id, xp=amount, vc_seconds=0, text_messages=0)
+    msg: str = f"✅ {user.display_name} に {amount:+,} XP 加算しました（Lv {old_level} → Lv {new_level}）。"
+    if new_level > old_level:
+        msg += " Lvアップ通知が所属寮のリーダーボードに投稿されます。"
+        await notify_level_up(user.id, old_level, new_level)
+    await ctx.respond(msg, ephemeral=True)
+
 
 # --- バックグラウンドタスク ---
 @tasks.loop(time=datetime.time(hour=12, minute=0, tzinfo=jst))
@@ -1526,13 +1697,15 @@ async def on_message(message: discord.Message) -> None:
                 return
         except ValueError:
             pass
-    add_contribution(
+    old_level, new_level = add_contribution(
         discord_id,
         xp=CONTRIBUTION_TEXT_PT_PER_MESSAGE,
         vc_seconds=0,
         text_messages=1,
         last_text_at_iso=now_utc.isoformat(),
     )
+    if new_level > old_level:
+        await notify_level_up(discord_id, old_level, new_level)
 
 
 @bot.event
@@ -1542,7 +1715,9 @@ async def on_voice_state_update(member: discord.Member, before: discord.VoiceSta
     if not member.bot and before.channel != after.channel:
         # 旧セッションを確定（退出 or 移動元）
         if before.channel is not None:
-            vc_session_end(member.id)
+            old_level, new_level = vc_session_end(member.id)
+            if new_level > old_level:
+                await notify_level_up(member.id, old_level, new_level)
         # 新セッション開始（入室 or 移動先）。組分け済みのみ計測対象
         if after.channel is not None and is_sorted(member.id):
             vc_session_start(member.id, after.channel.id)

--- a/main.py
+++ b/main.py
@@ -150,6 +150,17 @@ def setup_database() -> None:
             PRIMARY KEY (house_id, channel_type)
         )
     ''')
+    # 週次スナップショット: 週次ダイジェストの「先週比」算定に使用
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS weekly_snapshots (
+            snapshot_date  TEXT NOT NULL,
+            discord_id     INTEGER NOT NULL,
+            total_xp       INTEGER NOT NULL DEFAULT 0,
+            vc_seconds     INTEGER NOT NULL DEFAULT 0,
+            text_messages  INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (snapshot_date, discord_id)
+        )
+    ''')
     con.commit()
     con.close()
 # -----------------------------
@@ -866,6 +877,10 @@ async def on_ready() -> None:
 
     if not check_ranks_periodically.is_running():
         check_ranks_periodically.start()
+    if not weekly_digest_task.is_running():
+        weekly_digest_task.start()
+    if not monthly_summary_task.is_running():
+        monthly_summary_task.start()
 
 # --- コマンド ---
 @bot.slash_command(name="register", description="あなたのRiot IDをボットに登録します。", guild_ids=[DISCORD_GUILD_ID])
@@ -1573,6 +1588,352 @@ async def debug_grant_xp(
     await ctx.respond(msg, ephemeral=True)
 
 
+# --- 週次ダイジェスト / 月次サマリ ---
+DASHBOARD_URL: str = "https://pubview-dashboard.pages.dev/"
+
+
+def _bar10(progress: float) -> str:
+    """0.0〜1.0 を10段階のバー文字列に。"""
+    filled: int = max(0, min(10, round(progress * 10)))
+    return "▰" * filled + "▱" * (10 - filled)
+
+
+def _this_jst_monday(now_jst: datetime.datetime | None = None) -> datetime.date:
+    """今週月曜日のJST日付（土曜だったら今週月曜＝5日前）。"""
+    if now_jst is None:
+        now_jst = datetime.datetime.now(jst)
+    return (now_jst.date() - datetime.timedelta(days=now_jst.weekday()))
+
+
+def save_weekly_snapshot(snapshot_date: datetime.date) -> int:
+    """全組分け済みメンバーの現在累積をスナップショット保存。書き込んだ行数を返す。"""
+    iso_date: str = snapshot_date.isoformat()
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute(
+        """
+        INSERT OR REPLACE INTO weekly_snapshots (snapshot_date, discord_id, total_xp, vc_seconds, text_messages)
+        SELECT ?, s.discord_id,
+               COALESCE(t.total_xp, 0),
+               COALESCE(t.vc_seconds, 0),
+               COALESCE(t.text_messages, 0)
+        FROM sorting_hat s
+        LEFT JOIN contribution_totals t ON s.discord_id = t.discord_id
+        """,
+        (iso_date,),
+    )
+    written: int = cur.rowcount
+    con.commit()
+    con.close()
+    return written
+
+
+async def post_weekly_digest_for_house(house_id: str) -> str:
+    """指定寮の週次ダイジェストを 該当寮 リーダーボード へ投稿。
+
+    返り値: 結果サマリ文字列（デバッグコマンドが拾って表示）。
+    """
+    info: tuple[str, str, str, str] | None = next((h for h in HOUSES if h[0] == house_id), None)
+    if info is None:
+        return f"unknown house: {house_id}"
+    _, house_name_jp, house_emoji, _ = info
+
+    channel_id: int | None = get_house_channel_id(house_id, "leaderboard")
+    if channel_id is None:
+        return f"no leaderboard channel registered for {house_id}"
+    channel = bot.get_channel(channel_id)
+    if not isinstance(channel, discord.TextChannel):
+        return f"channel {channel_id} not text channel"
+
+    now_jst: datetime.datetime = datetime.datetime.now(jst)
+    this_monday: datetime.date = _this_jst_monday(now_jst)
+    last_monday: datetime.date = this_monday - datetime.timedelta(days=7)
+    this_sunday: datetime.date = this_monday + datetime.timedelta(days=6)
+
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    # 寮メンバー + 現在の累積 + 先週のスナップショット
+    cur.execute(
+        """
+        SELECT s.discord_id,
+               COALESCE(t.total_xp,     0) AS total_xp,
+               COALESCE(t.vc_seconds,   0) AS vc_seconds,
+               COALESCE(t.text_messages,0) AS text_messages,
+               COALESCE(ws.total_xp,    0) AS prev_xp,
+               COALESCE(ws.vc_seconds,  0) AS prev_vc,
+               COALESCE(ws.text_messages,0) AS prev_text,
+               (ws.discord_id IS NOT NULL) AS has_prev
+        FROM sorting_hat s
+        LEFT JOIN contribution_totals t ON s.discord_id = t.discord_id
+        LEFT JOIN weekly_snapshots   ws ON s.discord_id = ws.discord_id AND ws.snapshot_date = ?
+        WHERE s.house_id = ?
+        """,
+        (last_monday.isoformat(), house_id),
+    )
+    rows: list[tuple[int, int, int, int, int, int, int, int]] = cur.fetchall()
+    con.close()
+
+    if not rows:
+        try:
+            await channel.send(f"今週のダイジェスト: {house_emoji} {house_name_jp} はまだメンバーがいません。")
+        except Exception as e:
+            return f"send failed: {e}"
+        return f"{house_id}: no members"
+
+    has_baseline: bool = any(r[7] for r in rows)
+    members: list[dict[str, Any]] = []
+    for did, total_xp, vc_sec, txt, prev_xp, prev_vc, prev_text, has_prev in rows:
+        gained_xp: int = total_xp - prev_xp if has_prev else 0  # 初回はゼロ表示（先週比なし）
+        gained_vc: int = vc_sec - prev_vc if has_prev else 0
+        gained_text: int = txt - prev_text if has_prev else 0
+        members.append({
+            "discord_id": did,
+            "total_xp": total_xp,
+            "gained_xp": gained_xp,
+            "gained_vc": gained_vc,
+            "gained_text": gained_text,
+            "level": level_from_xp(total_xp),
+        })
+
+    members.sort(key=lambda m: m["gained_xp"], reverse=True)
+
+    house_gained: int = sum(m["gained_xp"] for m in members)
+    active_count: int = sum(1 for m in members if m["gained_xp"] > 0)
+    member_count: int = len(members)
+    total_vc: int = sum(m["gained_vc"] for m in members)
+    total_text: int = sum(m["gained_text"] for m in members)
+
+    # KPIs
+    kpi_lines: list[str] = [
+        f"├ 今週の獲得pt: **+{house_gained:,} pt**",
+        f"├ 参加メンバー: **{active_count}/{member_count}** ({(active_count/max(1,member_count)*100):.1f}%)",
+        f"├ VC在室時間: **{total_vc//3600}h {(total_vc%3600)//60}m**",
+        f"└ テキスト投稿: **{total_text:,}件**",
+    ]
+
+    # トップコントリビューター（上位5）
+    top_lines: list[str] = []
+    for i, m in enumerate(members[:5], start=1):
+        lv: int = m["level"]
+        cur_xp: int = required_xp_for_level(lv)
+        next_xp: int = required_xp_for_level(lv + 1)
+        in_lv: int = m["total_xp"] - cur_xp
+        span: int = max(1, next_xp - cur_xp)
+        share: float = (m["gained_xp"] / house_gained * 100) if house_gained > 0 else 0.0
+        bar: str = _bar10(in_lv / span)
+        top_lines.append(
+            f"<@{m['discord_id']}> **Lv.{lv}** ({in_lv:,}/{span:,} XP)\n"
+            f"{bar} **+{m['gained_xp']:,} pt** ({share:.1f}%)"
+        )
+
+    # 寮間順位算出
+    standings: list[tuple[str, int]] = []
+    con2: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur2: sqlite3.Cursor = con2.cursor()
+    for h in HOUSES:
+        cur2.execute(
+            """
+            SELECT COALESCE(SUM(t.total_xp - COALESCE(ws.total_xp, 0)), 0)
+            FROM sorting_hat s
+            LEFT JOIN contribution_totals t ON s.discord_id = t.discord_id
+            LEFT JOIN weekly_snapshots   ws ON s.discord_id = ws.discord_id AND ws.snapshot_date = ?
+            WHERE s.house_id = ?
+            """,
+            (last_monday.isoformat(), h[0]),
+        )
+        result: tuple[int] = cur2.fetchone()
+        standings.append((h[0], result[0]))
+    con2.close()
+    standings.sort(key=lambda x: x[1], reverse=True)
+    rank: int = next((i for i, (hid, _) in enumerate(standings, start=1) if hid == house_id), 0)
+    rank_line: str = ""
+    if rank == 1 and len(standings) > 1:
+        runner_up_pt: int = standings[1][1]
+        rank_line = f"🏃 順位: **4寮中 1位** / 2位{HOUSE_BY_ID[standings[1][0]][1]}との差 +{house_gained - runner_up_pt:,} pt"
+    elif rank >= 2:
+        leader_pt: int = standings[0][1]
+        rank_line = f"🏃 順位: 4寮中 {rank}位 / 1位{HOUSE_BY_ID[standings[0][0]][1]}まで +{leader_pt - house_gained:,} pt"
+
+    desc: str = "\n".join(kpi_lines)
+    embed: discord.Embed = discord.Embed(
+        title=f"{house_emoji} {house_name_jp} 週次ダイジェスト",
+        description=(
+            f"📅 {this_monday.strftime('%Y年%m月%d日')} 〜 {this_sunday.strftime('%Y年%m月%d日')}\n\n"
+            f"📊 主要指標 (KPIs)\n{desc}"
+        ),
+        color=discord.Color.dark_purple(),
+    )
+    if not has_baseline:
+        embed.add_field(name="📌 注記", value="初回計測（先週比なし）", inline=False)
+    if top_lines:
+        embed.add_field(name="🏆 トップコントリビューター", value="\n\n".join(top_lines)[:1024], inline=False)
+    if rank_line:
+        embed.add_field(name="📈 トレンド", value=rank_line, inline=False)
+    embed.set_footer(text=f"Webダッシュボード: {DASHBOARD_URL}")
+    try:
+        await channel.send(
+            embed=embed,
+            allowed_mentions=discord.AllowedMentions(everyone=False, roles=False, users=False),
+        )
+    except Exception as e:
+        return f"send failed: {e}"
+    return f"{house_id}: posted ({house_gained:,} pt, {active_count}/{member_count} active)"
+
+
+async def post_weekly_digest_all() -> list[str]:
+    """4寮の週次ダイジェストを投稿し、最後に新スナップショットを保存。"""
+    summaries: list[str] = []
+    for h in HOUSES:
+        summary: str = await post_weekly_digest_for_house(h[0])
+        summaries.append(summary)
+    today: datetime.date = _this_jst_monday()
+    save_weekly_snapshot(today)
+    return summaries
+
+
+async def post_monthly_summary(year_month_override: str | None = None) -> str:
+    """月次サマリを NOTIFICATION_CHANNEL_ID へ投稿。
+
+    year_month_override が None の場合は「先月」を対象（毎月1日0:00発火想定）。
+    """
+    now_jst: datetime.datetime = datetime.datetime.now(jst)
+    if year_month_override is not None:
+        target_ym: str = year_month_override
+    else:
+        prev_month_last_day: datetime.date = now_jst.date().replace(day=1) - datetime.timedelta(days=1)
+        target_ym = prev_month_last_day.strftime("%Y-%m")
+
+    channel = bot.get_channel(NOTIFICATION_CHANNEL_ID)
+    if not isinstance(channel, discord.TextChannel):
+        return f"NOTIFICATION_CHANNEL_ID {NOTIFICATION_CHANNEL_ID} not text channel"
+
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+
+    # 寮別合計
+    cur.execute(
+        """
+        SELECT s.house_id, COALESCE(SUM(m.points), 0) AS pt, COUNT(DISTINCT s.discord_id) AS members
+        FROM sorting_hat s
+        LEFT JOIN contribution_monthly m ON s.discord_id = m.discord_id AND m.year_month = ?
+        GROUP BY s.house_id
+        """,
+        (target_ym,),
+    )
+    house_rows: list[tuple[str, int, int]] = cur.fetchall()
+    house_rows.sort(key=lambda r: r[1], reverse=True)
+
+    # 個人MVP Top5
+    cur.execute(
+        """
+        SELECT m.discord_id, s.house_id, m.points
+        FROM contribution_monthly m
+        JOIN sorting_hat s ON m.discord_id = s.discord_id
+        WHERE m.year_month = ?
+        ORDER BY m.points DESC
+        LIMIT 5
+        """,
+        (target_ym,),
+    )
+    mvp_rows: list[tuple[int, str, int]] = cur.fetchall()
+    con.close()
+
+    medals: list[str] = ["🥇", "🥈", "🥉", "4️⃣", "5️⃣"]
+    house_lines: list[str] = []
+    for i, (house_id, pt, members) in enumerate(house_rows):
+        info: tuple[str, str, str, str] = HOUSE_BY_ID[house_id]
+        medal: str = medals[i] if i < len(medals) else f"{i+1}."
+        house_lines.append(f"{medal} {info[2]} {info[1]} — **{pt:,} pt** ({members}人)")
+    mvp_lines: list[str] = []
+    if mvp_rows:
+        for i, (did, hid, pt) in enumerate(mvp_rows, start=1):
+            house_emoji: str = HOUSE_BY_ID[hid][2]
+            mvp_lines.append(f"`#{i}` {house_emoji} <@{did}> — **{pt:,} pt**")
+
+    embed: discord.Embed = discord.Embed(
+        title=f"📅 {target_ym} 月次サマリ",
+        color=discord.Color.gold(),
+    )
+    embed.add_field(
+        name="🏰 寮対抗ランキング",
+        value="\n".join(house_lines) if house_lines else "（記録なし）",
+        inline=False,
+    )
+    embed.add_field(
+        name="🌟 個人MVP Top 5",
+        value="\n".join(mvp_lines) if mvp_lines else "（記録なし）",
+        inline=False,
+    )
+    embed.set_footer(text=f"Webダッシュボード: {DASHBOARD_URL}")
+    try:
+        await channel.send(
+            embed=embed,
+            allowed_mentions=discord.AllowedMentions(everyone=False, roles=False, users=False),
+        )
+    except Exception as e:
+        return f"send failed: {e}"
+    return f"posted monthly summary for {target_ym}"
+# -----------------------------
+
+
+# --- デバッグ用: ダイジェスト/サマリ手動投稿 ---
+@bot.slash_command(
+    name="debug_post_weekly_digest",
+    description="週次寮ダイジェストを手動投稿します。house 指定なしで全寮。（デバッグ用）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def debug_post_weekly_digest(
+    ctx: discord.ApplicationContext,
+    house: discord.Option(  # type: ignore[valid-type]
+        str,
+        "対象寮（省略時は全寮）",
+        choices=["raptor", "krug", "wolf", "gromp", "all"],
+        default="all",
+    ),
+) -> None:
+    await ctx.defer(ephemeral=True)
+    if house == "all":
+        summaries: list[str] = await post_weekly_digest_all()
+        await ctx.respond("✅ 全寮ダイジェスト投稿\n" + "\n".join(f"- {s}" for s in summaries), ephemeral=True)
+    else:
+        summary: str = await post_weekly_digest_for_house(house)
+        await ctx.respond(f"✅ ダイジェスト投稿: {summary}", ephemeral=True)
+
+
+@bot.slash_command(
+    name="debug_post_monthly_summary",
+    description="月次サマリを手動投稿します。（デバッグ用）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def debug_post_monthly_summary(
+    ctx: discord.ApplicationContext,
+    year_month: discord.Option(  # type: ignore[valid-type]
+        str,
+        "対象年月 (例: 2026-05)。省略時は先月。",
+        default="",
+    ) = "",
+) -> None:
+    await ctx.defer(ephemeral=True)
+    ym_arg: str | None = year_month if year_month else None
+    result: str = await post_monthly_summary(ym_arg)
+    await ctx.respond(f"✅ {result}", ephemeral=True)
+
+
+@bot.slash_command(
+    name="debug_save_weekly_snapshot",
+    description="今この瞬間の週次スナップショットを保存します。（デバッグ用）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def debug_save_weekly_snapshot(ctx: discord.ApplicationContext) -> None:
+    await ctx.defer(ephemeral=True)
+    today: datetime.date = _this_jst_monday()
+    n: int = save_weekly_snapshot(today)
+    await ctx.respond(f"✅ snapshot saved: date={today.isoformat()} rows={n}", ephemeral=True)
+
+
 # --- バックグラウンドタスク ---
 @tasks.loop(time=datetime.time(hour=12, minute=0, tzinfo=jst))
 async def check_ranks_periodically() -> None:
@@ -1674,6 +2035,30 @@ async def check_ranks_periodically() -> None:
             await channel.send(f"🎉 **ランクアップ！** 🎉\nおめでとうございます、{user_data['member'].mention}さん ({riot_id_full})！\n**{user_data['old_tier']} {user_data['old_rank']}** → **{user_data['new_tier']} {user_data['new_rank']}** に昇格しました！")
 
     print("--- Periodic rank check finished ---")
+
+
+# 週次寮ダイジェスト: 毎日 10:00 JST に発火 → 月曜だけ実投稿
+@tasks.loop(time=datetime.time(hour=10, minute=0, tzinfo=jst))
+async def weekly_digest_task() -> None:
+    now_jst: datetime.datetime = datetime.datetime.now(jst)
+    if now_jst.weekday() != 0:  # 0 = Monday
+        return
+    print(f"--- weekly_digest_task firing on {now_jst.isoformat()} ---")
+    summaries: list[str] = await post_weekly_digest_all()
+    for s in summaries:
+        print(f"  weekly_digest: {s}")
+
+
+# 月次サマリ: 毎日 0:00 JST に発火 → 1日だけ実投稿
+@tasks.loop(time=datetime.time(hour=0, minute=0, tzinfo=jst))
+async def monthly_summary_task() -> None:
+    now_jst: datetime.datetime = datetime.datetime.now(jst)
+    if now_jst.day != 1:
+        return
+    print(f"--- monthly_summary_task firing on {now_jst.isoformat()} ---")
+    result: str = await post_monthly_summary()
+    print(f"  monthly_summary: {result}")
+
 
 @bot.event
 async def on_message(message: discord.Message) -> None:

--- a/main.py
+++ b/main.py
@@ -2,9 +2,11 @@ import os
 import sqlite3
 import datetime
 import time
+import json
 import random
 import string
 from typing import Any
+import aiohttp
 import discord
 from discord.ext import tasks
 from riotwatcher import RiotWatcher, LolWatcher, ApiError
@@ -15,6 +17,9 @@ DISCORD_TOKEN: str | None = os.getenv('DISCORD_TOKEN')
 RIOT_API_KEY: str | None = os.getenv('RIOT_API_KEY')
 DISCORD_GUILD_ID: int = int(os.getenv('DISCORD_GUILD_ID'))
 DB_PATH: str = '/data/lol_bot.db'
+CLOUDFLARE_INGEST_URL: str | None = os.getenv('CLOUDFLARE_INGEST_URL')
+INGEST_TOKEN: str | None = os.getenv('INGEST_TOKEN')
+BOT_VERSION: str = "phase3-2"
 NOTIFICATION_CHANNEL_ID: int = 1401719055643312219 # 通知用チャンネルID
 HONOR_CHANNEL_ID: int = 1447166222591594607 # 名誉用チャンネルID
 VOICE_CREATE_CHANNEL_ID: int = 1469467862358823125
@@ -159,6 +164,15 @@ def setup_database() -> None:
             vc_seconds     INTEGER NOT NULL DEFAULT 0,
             text_messages  INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (snapshot_date, discord_id)
+        )
+    ''')
+    # 寮長: 管理者が手動で任命。D1への同期も同形式
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS house_leaders (
+            house_id   TEXT PRIMARY KEY,
+            discord_id INTEGER NOT NULL,
+            set_at     TEXT NOT NULL,
+            set_by     INTEGER
         )
     ''')
     con.commit()
@@ -881,6 +895,11 @@ async def on_ready() -> None:
         weekly_digest_task.start()
     if not monthly_summary_task.is_running():
         monthly_summary_task.start()
+    if CLOUDFLARE_INGEST_URL and INGEST_TOKEN and not sync_to_d1_task.is_running():
+        sync_to_d1_task.start()
+        print("--- D1 sync task started (5min interval) ---")
+    elif not (CLOUDFLARE_INGEST_URL and INGEST_TOKEN):
+        print("--- D1 sync task SKIPPED: CLOUDFLARE_INGEST_URL / INGEST_TOKEN not set ---")
 
 # --- コマンド ---
 @bot.slash_command(name="register", description="あなたのRiot IDをボットに登録します。", guild_ids=[DISCORD_GUILD_ID])
@@ -1386,6 +1405,84 @@ async def setup_house_channels(ctx: discord.ApplicationContext) -> None:
     msg: str = "**寮チャンネルセットアップ完了**\n" + "\n".join(summary_lines)
     await ctx.respond(msg, ephemeral=True)
 
+
+@bot.slash_command(
+    name="set_house_leader",
+    description="指定ユーザーをその寮の寮長に任命します。（管理者向け）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def set_house_leader(
+    ctx: discord.ApplicationContext,
+    house: discord.Option(  # type: ignore[valid-type]
+        str,
+        "対象寮",
+        choices=["raptor", "krug", "wolf", "gromp"],
+    ),
+    user: discord.Member,
+) -> None:
+    """対象ユーザーを寮長に任命。対象は同寮所属のメンバーであることを推奨（ただし制約はかけない）。"""
+    await ctx.defer(ephemeral=True)
+    user_house: str | None = get_user_house_id(user.id)
+    info: tuple[str, str, str, str] | None = next((h for h in HOUSES if h[0] == house), None)
+    if info is None:
+        await ctx.respond(f"unknown house: {house}", ephemeral=True)
+        return
+    now_iso: str = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute(
+        "INSERT OR REPLACE INTO house_leaders (house_id, discord_id, set_at, set_by) VALUES (?, ?, ?, ?)",
+        (house, user.id, now_iso, ctx.author.id),
+    )
+    con.commit()
+    con.close()
+    warn: str = ""
+    if user_house is None:
+        warn = "\n⚠️ 対象ユーザーはまだ組分け帽子を被っていません。"
+    elif user_house != house:
+        warn = f"\n⚠️ 対象ユーザーは別の寮 ({_house_name(user_house)}) に所属しています。"
+    await ctx.respond(
+        f"✅ {info[2]} {info[1]} の寮長に {user.mention} を任命しました。{warn}\n"
+        "次回 D1 同期 (5分以内) でダッシュボードに反映されます。",
+        ephemeral=True,
+    )
+
+
+@bot.slash_command(
+    name="clear_house_leader",
+    description="指定寮の寮長任命を解除します。（管理者向け）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def clear_house_leader(
+    ctx: discord.ApplicationContext,
+    house: discord.Option(  # type: ignore[valid-type]
+        str,
+        "対象寮",
+        choices=["raptor", "krug", "wolf", "gromp"],
+    ),
+) -> None:
+    await ctx.defer(ephemeral=True)
+    info: tuple[str, str, str, str] | None = next((h for h in HOUSES if h[0] == house), None)
+    if info is None:
+        await ctx.respond(f"unknown house: {house}", ephemeral=True)
+        return
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute("DELETE FROM house_leaders WHERE house_id = ?", (house,))
+    changed: int = cur.rowcount
+    con.commit()
+    con.close()
+    if changed == 0:
+        await ctx.respond(f"{info[2]} {info[1]} には寮長が任命されていません。", ephemeral=True)
+    else:
+        await ctx.respond(
+            f"✅ {info[2]} {info[1]} の寮長任命を解除しました。次回 D1 同期で反映されます。",
+            ephemeral=True,
+        )
+
+
 @bot.slash_command(name="add_section", description="参加可能なセクションを登録します。（管理者向け）", guild_ids=[DISCORD_GUILD_ID])
 @discord.default_permissions(administrator=True)
 async def add_section(ctx: discord.ApplicationContext, section_role: discord.Role, notification_channel: discord.TextChannel) -> None:
@@ -1876,6 +1973,116 @@ async def post_monthly_summary(year_month_override: str | None = None) -> str:
 # -----------------------------
 
 
+# --- Bot → D1 同期 ---
+async def sync_to_d1() -> dict[str, Any]:
+    """Bot SQLite の全テーブルを取得して /api/ingest へ POST する。
+
+    返り値: {ok: bool, status, counts, error?}
+    """
+    if not CLOUDFLARE_INGEST_URL or not INGEST_TOKEN:
+        return {"ok": False, "error": "CLOUDFLARE_INGEST_URL / INGEST_TOKEN unset"}
+
+    guild: discord.Guild | None = bot.get_guild(DISCORD_GUILD_ID)
+    if guild is None:
+        return {"ok": False, "error": f"guild {DISCORD_GUILD_ID} not in cache"}
+
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+
+    # users: Bot DB の Riot 情報 + Discord プロフィール（display_name/avatar）を結合
+    cur.execute("SELECT discord_id, game_name, tag_line, tier, rank, league_points FROM users")
+    riot_users: dict[int, tuple[str | None, str | None, str | None, str | None, int | None]] = {
+        row[0]: (row[1], row[2], row[3], row[4], row[5]) for row in cur.fetchall()
+    }
+
+    # sorting_hat 配下の discord_id も含めて users 配列に入れる
+    cur.execute("SELECT discord_id FROM sorting_hat")
+    sorted_ids: set[int] = {row[0] for row in cur.fetchall()}
+    all_discord_ids: set[int] = set(riot_users.keys()) | sorted_ids
+    # house_leaders, contribution_totals/monthly に居るが他に無いユーザーもDiscordプロファイル必要
+    cur.execute("SELECT discord_id FROM contribution_totals")
+    for r in cur.fetchall(): all_discord_ids.add(r[0])
+    cur.execute("SELECT discord_id FROM house_leaders")
+    for r in cur.fetchall(): all_discord_ids.add(r[0])
+
+    users_payload: list[dict[str, Any]] = []
+    for did in all_discord_ids:
+        member: discord.Member | None = guild.get_member(did)
+        if member is None:
+            try:
+                member = await guild.fetch_member(did)
+            except Exception:
+                member = None
+        display_name: str = member.display_name if member is not None else f"user_{did}"
+        avatar_url: str | None = str(member.display_avatar.url) if member is not None else None
+        game_name, tag_line, tier, rank_, lp = riot_users.get(did, (None, None, None, None, None))
+        users_payload.append({
+            "discord_id": str(did),
+            "display_name": display_name,
+            "avatar_url": avatar_url,
+            "riot_game_name": game_name,
+            "riot_tag_line": tag_line,
+            "tier": tier,
+            "rank": rank_,
+            "league_points": lp,
+        })
+
+    cur.execute("SELECT discord_id, house_id, rate_bracket, tier, sorted_at FROM sorting_hat")
+    sorting_payload: list[dict[str, Any]] = [
+        {"discord_id": str(r[0]), "house_id": r[1], "rate_bracket": r[2], "tier": r[3], "sorted_at": r[4]}
+        for r in cur.fetchall()
+    ]
+
+    cur.execute("SELECT discord_id, total_xp, vc_seconds, text_messages, updated_at FROM contribution_totals")
+    totals_payload: list[dict[str, Any]] = [
+        {"discord_id": str(r[0]), "total_xp": r[1], "vc_seconds": r[2], "text_messages": r[3], "updated_at": r[4]}
+        for r in cur.fetchall()
+    ]
+
+    cur.execute("SELECT year_month, discord_id, points, vc_seconds, text_messages FROM contribution_monthly")
+    monthly_payload: list[dict[str, Any]] = [
+        {"year_month": r[0], "discord_id": str(r[1]), "points": r[2], "vc_seconds": r[3], "text_messages": r[4]}
+        for r in cur.fetchall()
+    ]
+
+    cur.execute("SELECT house_id, discord_id, set_at, set_by FROM house_leaders")
+    leaders_payload: list[dict[str, Any]] = [
+        {"house_id": r[0], "discord_id": str(r[1]), "set_at": r[2], "set_by": str(r[3]) if r[3] else None}
+        for r in cur.fetchall()
+    ]
+    con.close()
+
+    body: dict[str, Any] = {
+        "bot_version": BOT_VERSION,
+        "users": users_payload,
+        "sorting_hat": sorting_payload,
+        "contribution_totals": totals_payload,
+        "contribution_monthly": monthly_payload,
+        "house_leaders": leaders_payload,
+    }
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                CLOUDFLARE_INGEST_URL,
+                headers={"Authorization": f"Bearer {INGEST_TOKEN}", "Content-Type": "application/json"},
+                data=json.dumps(body),
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                status: int = resp.status
+                text: str = await resp.text()
+    except Exception as e:
+        return {"ok": False, "error": f"request failed: {e}"}
+
+    if status != 200:
+        return {"ok": False, "status": status, "error": text[:300]}
+    try:
+        result: dict[str, Any] = json.loads(text)
+    except Exception:
+        result = {"raw": text}
+    return {"ok": True, "status": status, "counts": result.get("counts", {})}
+# -----------------------------
+
+
 # --- デバッグ用: ダイジェスト/サマリ手動投稿 ---
 @bot.slash_command(
     name="debug_post_weekly_digest",
@@ -1932,6 +2139,25 @@ async def debug_save_weekly_snapshot(ctx: discord.ApplicationContext) -> None:
     today: datetime.date = _this_jst_monday()
     n: int = save_weekly_snapshot(today)
     await ctx.respond(f"✅ snapshot saved: date={today.isoformat()} rows={n}", ephemeral=True)
+
+
+@bot.slash_command(
+    name="debug_force_sync",
+    description="Cloudflare D1 への同期を即時実行します。（デバッグ用）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def debug_force_sync(ctx: discord.ApplicationContext) -> None:
+    await ctx.defer(ephemeral=True)
+    result: dict[str, Any] = await sync_to_d1()
+    if result.get("ok"):
+        counts: dict[str, int] = result.get("counts", {})
+        await ctx.respond(
+            f"✅ 同期成功\n```json\n{json.dumps(counts, indent=2, ensure_ascii=False)}\n```",
+            ephemeral=True,
+        )
+    else:
+        await ctx.respond(f"❌ 同期失敗\nstatus={result.get('status')} error={result.get('error')}", ephemeral=True)
 
 
 # --- バックグラウンドタスク ---
@@ -2058,6 +2284,19 @@ async def monthly_summary_task() -> None:
     print(f"--- monthly_summary_task firing on {now_jst.isoformat()} ---")
     result: str = await post_monthly_summary()
     print(f"  monthly_summary: {result}")
+
+
+# Bot → Cloudflare D1: 5分おきに全件同期
+@tasks.loop(minutes=5)
+async def sync_to_d1_task() -> None:
+    if not CLOUDFLARE_INGEST_URL or not INGEST_TOKEN:
+        return  # 環境変数なしのときは何もしない
+    result: dict[str, Any] = await sync_to_d1()
+    if result.get("ok"):
+        counts: dict[str, int] = result.get("counts", {})
+        print(f"--- sync_to_d1 OK: {counts} ---")
+    else:
+        print(f"!!! sync_to_d1 FAILED: status={result.get('status')} error={result.get('error')}")
 
 
 @bot.event

--- a/main.py
+++ b/main.py
@@ -166,6 +166,17 @@ def setup_database() -> None:
             PRIMARY KEY (snapshot_date, discord_id)
         )
     ''')
+    # 日次スナップショット: 個人ページの「日次成果グラフ」算定に使用
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS daily_snapshots (
+            snapshot_date  TEXT NOT NULL,
+            discord_id     INTEGER NOT NULL,
+            total_xp       INTEGER NOT NULL DEFAULT 0,
+            vc_seconds     INTEGER NOT NULL DEFAULT 0,
+            text_messages  INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (snapshot_date, discord_id)
+        )
+    ''')
     # 寮長: 管理者が手動で任命。D1への同期も同形式
     cur.execute('''
         CREATE TABLE IF NOT EXISTS house_leaders (
@@ -911,6 +922,21 @@ async def on_ready() -> None:
         weekly_digest_task.start()
     if not monthly_summary_task.is_running():
         monthly_summary_task.start()
+    if not daily_snapshot_task.is_running():
+        daily_snapshot_task.start()
+    # 起動時、今日のスナップショットが無ければ取る（個人ページのグラフが初回から表示できるように）
+    try:
+        today_jst: datetime.date = datetime.datetime.now(jst).date()
+        _con_ds: sqlite3.Connection = sqlite3.connect(DB_PATH)
+        _cur_ds: sqlite3.Cursor = _con_ds.cursor()
+        _cur_ds.execute("SELECT COUNT(*) FROM daily_snapshots WHERE snapshot_date = ?", (today_jst.isoformat(),))
+        _exists: int = _cur_ds.fetchone()[0]
+        _con_ds.close()
+        if _exists == 0:
+            save_daily_snapshot(today_jst)
+            print(f"--- daily_snapshot bootstrap for {today_jst.isoformat()} ---")
+    except Exception as e:
+        print(f"!!! daily_snapshot bootstrap failed: {e}")
     if CLOUDFLARE_INGEST_URL and INGEST_TOKEN and not sync_to_d1_task.is_running():
         sync_to_d1_task.start()
         print("--- D1 sync task started (5min interval) ---")
@@ -1748,6 +1774,29 @@ def save_weekly_snapshot(snapshot_date: datetime.date) -> int:
     return written
 
 
+def save_daily_snapshot(snapshot_date: datetime.date) -> int:
+    """全組分け済みメンバーの現在累積を日次スナップショットへ保存。"""
+    iso_date: str = snapshot_date.isoformat()
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute(
+        """
+        INSERT OR REPLACE INTO daily_snapshots (snapshot_date, discord_id, total_xp, vc_seconds, text_messages)
+        SELECT ?, s.discord_id,
+               COALESCE(t.total_xp, 0),
+               COALESCE(t.vc_seconds, 0),
+               COALESCE(t.text_messages, 0)
+        FROM sorting_hat s
+        LEFT JOIN contribution_totals t ON s.discord_id = t.discord_id
+        """,
+        (iso_date,),
+    )
+    written: int = cur.rowcount
+    con.commit()
+    con.close()
+    return written
+
+
 async def post_weekly_digest_for_house(house_id: str) -> str:
     """指定寮の週次ダイジェストを 該当寮 リーダーボード へ投稿。
 
@@ -2085,6 +2134,17 @@ async def sync_to_d1() -> dict[str, Any]:
         {"house_id": r[0], "discord_id": str(r[1]), "set_at": r[2], "set_by": str(r[3]) if r[3] else None}
         for r in cur.fetchall()
     ]
+
+    # 直近60日分の日次スナップショット（個人ページのグラフ用）
+    cutoff_jst: datetime.date = datetime.datetime.now(jst).date() - datetime.timedelta(days=60)
+    cur.execute(
+        "SELECT snapshot_date, discord_id, total_xp, vc_seconds, text_messages FROM daily_snapshots WHERE snapshot_date >= ?",
+        (cutoff_jst.isoformat(),),
+    )
+    daily_payload: list[dict[str, Any]] = [
+        {"snapshot_date": r[0], "discord_id": str(r[1]), "total_xp": r[2], "vc_seconds": r[3], "text_messages": r[4]}
+        for r in cur.fetchall()
+    ]
     con.close()
 
     body: dict[str, Any] = {
@@ -2094,6 +2154,7 @@ async def sync_to_d1() -> dict[str, Any]:
         "contribution_totals": totals_payload,
         "contribution_monthly": monthly_payload,
         "house_leaders": leaders_payload,
+        "daily_snapshots": daily_payload,
     }
     try:
         async with aiohttp.ClientSession() as session:
@@ -2174,6 +2235,19 @@ async def debug_save_weekly_snapshot(ctx: discord.ApplicationContext) -> None:
     today: datetime.date = _this_jst_monday()
     n: int = save_weekly_snapshot(today)
     await ctx.respond(f"✅ snapshot saved: date={today.isoformat()} rows={n}", ephemeral=True)
+
+
+@bot.slash_command(
+    name="debug_save_daily_snapshot",
+    description="今日（JST）の日次スナップショットを即時保存します。（デバッグ用）",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+@discord.default_permissions(administrator=True)
+async def debug_save_daily_snapshot(ctx: discord.ApplicationContext) -> None:
+    await ctx.defer(ephemeral=True)
+    today: datetime.date = datetime.datetime.now(jst).date()
+    n: int = save_daily_snapshot(today)
+    await ctx.respond(f"✅ daily snapshot saved: date={today.isoformat()} rows={n}", ephemeral=True)
 
 
 @bot.slash_command(
@@ -2319,6 +2393,14 @@ async def monthly_summary_task() -> None:
     print(f"--- monthly_summary_task firing on {now_jst.isoformat()} ---")
     result: str = await post_monthly_summary()
     print(f"  monthly_summary: {result}")
+
+
+# 日次スナップショット: 毎日 0:00 JST 発火（個人ページの日次グラフ用）
+@tasks.loop(time=datetime.time(hour=0, minute=0, tzinfo=jst))
+async def daily_snapshot_task() -> None:
+    today: datetime.date = datetime.datetime.now(jst).date()
+    n: int = save_daily_snapshot(today)
+    print(f"--- daily_snapshot {today.isoformat()}: {n} rows ---")
 
 
 # Bot → Cloudflare D1: 5分おきに全件同期

--- a/main.py
+++ b/main.py
@@ -938,6 +938,184 @@ async def score(ctx: discord.ApplicationContext) -> None:
     await ctx.respond(embed=embed, ephemeral=True)
 
 
+# --- /leaderboard / /house_standings: 貢献度ランキング系 ---
+HOUSE_BY_ID: dict[str, tuple[str, str, str, str]] = {h[0]: h for h in HOUSES}
+
+
+def _house_emoji(house_id: str) -> str:
+    h: tuple[str, str, str, str] | None = HOUSE_BY_ID.get(house_id)
+    return h[2] if h else "❔"
+
+
+def _house_name(house_id: str) -> str:
+    h: tuple[str, str, str, str] | None = HOUSE_BY_ID.get(house_id)
+    return h[1] if h else "?"
+
+
+def _fmt_int(n: int) -> str:
+    return f"{n:,}"
+
+
+@bot.slash_command(
+    name="leaderboard",
+    description="個人のコントリビューションランキング（Top10）を表示します。",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+async def leaderboard(
+    ctx: discord.ApplicationContext,
+    mode: discord.Option(  # type: ignore[valid-type]
+        str,
+        "並び替え基準",
+        choices=["monthly", "total"],
+        default="monthly",
+    ),
+) -> None:
+    """組分け済みメンバーの貢献度Top10。mode=monthly: 今月pt順 / mode=total: 累積XP順"""
+    await ctx.defer()
+
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    ym: str = current_year_month_jst()
+
+    if mode == "total":
+        cur.execute(
+            """
+            SELECT s.discord_id, s.house_id,
+                   COALESCE(t.total_xp, 0)   AS total_xp,
+                   COALESCE(m.points, 0)     AS month_pt
+            FROM sorting_hat s
+            LEFT JOIN contribution_totals  t ON s.discord_id = t.discord_id
+            LEFT JOIN contribution_monthly m ON s.discord_id = m.discord_id AND m.year_month = ?
+            ORDER BY total_xp DESC
+            LIMIT 10
+            """,
+            (ym,),
+        )
+        title: str = "🏆 累積XPランキング（Top 10）"
+        primary_label: str = "XP"
+    else:
+        cur.execute(
+            """
+            SELECT s.discord_id, s.house_id,
+                   COALESCE(t.total_xp, 0)   AS total_xp,
+                   COALESCE(m.points, 0)     AS month_pt
+            FROM sorting_hat s
+            LEFT JOIN contribution_totals  t ON s.discord_id = t.discord_id
+            LEFT JOIN contribution_monthly m ON s.discord_id = m.discord_id AND m.year_month = ?
+            ORDER BY month_pt DESC, total_xp DESC
+            LIMIT 10
+            """,
+            (ym,),
+        )
+        title: str = f"🏆 今月の貢献度ランキング（{ym} / Top 10）"
+        primary_label: str = "pt"
+
+    rows: list[tuple[int, str, int, int]] = cur.fetchall()
+    con.close()
+
+    embed: discord.Embed = discord.Embed(title=title, color=discord.Color.gold())
+    if not rows:
+        embed.description = "まだ組分けされたメンバーがいないか、貢献度の記録がありません。"
+        await ctx.respond(embed=embed)
+        return
+
+    lines: list[str] = []
+    guild: discord.Guild | None = ctx.guild
+    for i, (discord_id, house_id, total_xp, month_pt) in enumerate(rows, start=1):
+        member_name: str = f"<@{discord_id}>"
+        # ユーザー削除済みのフォールバック
+        if guild is not None:
+            member: discord.Member | None = guild.get_member(discord_id)
+            if member is None:
+                try:
+                    member = await guild.fetch_member(discord_id)
+                except Exception:
+                    member = None
+            if member is not None:
+                member_name = member.mention
+        lv: int = level_from_xp(total_xp)
+        value: int = total_xp if mode == "total" else month_pt
+        lines.append(
+            f"`#{i:>2}` {_house_emoji(house_id)} {member_name} ・ Lv {lv} ・ **{_fmt_int(value)} {primary_label}**"
+        )
+
+    embed.description = "\n".join(lines)
+    embed.set_footer(
+        text=(
+            "mode=total: 累積XP順 / mode=monthly: 今月pt順"
+            f"\nWebダッシュボード: https://pubview-dashboard.pages.dev/"
+        )
+    )
+    await ctx.respond(embed=embed)
+
+
+@bot.slash_command(
+    name="house_standings",
+    description="4寮のコントリビューション対抗状況を表示します。",
+    guild_ids=[DISCORD_GUILD_ID],
+)
+async def house_standings(ctx: discord.ApplicationContext) -> None:
+    """寮ごとの 寮Lv / 累積XP / 今月pt / メンバー数 を1枚で表示。"""
+    await ctx.defer()
+
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    ym: str = current_year_month_jst()
+
+    cur.execute(
+        """
+        SELECT s.house_id,
+               COUNT(DISTINCT s.discord_id)   AS member_count,
+               COALESCE(SUM(t.total_xp), 0)    AS total_xp,
+               COALESCE(SUM(m.points),  0)    AS month_pt
+        FROM sorting_hat s
+        LEFT JOIN contribution_totals  t ON s.discord_id = t.discord_id
+        LEFT JOIN contribution_monthly m ON s.discord_id = m.discord_id AND m.year_month = ?
+        GROUP BY s.house_id
+        """,
+        (ym,),
+    )
+    stats_by_house: dict[str, tuple[int, int, int]] = {
+        row[0]: (row[1], row[2], row[3]) for row in cur.fetchall()
+    }
+    con.close()
+
+    embed: discord.Embed = discord.Embed(
+        title=f"🏰 寮対抗スタンディング（{ym}）",
+        color=discord.Color.dark_purple(),
+    )
+
+    # 寮Lv 順、同点は今月pt降順
+    ordered: list[tuple[str, int, int, int, int]] = []
+    for house_id, name_jp, emoji, _role in HOUSES:
+        member_count, total_xp, month_pt = stats_by_house.get(house_id, (0, 0, 0))
+        house_lv: int = level_from_xp(total_xp, CONTRIBUTION_HOUSE_LEVEL_COEF, CONTRIBUTION_HOUSE_LEVEL_EXP)
+        ordered.append((house_id, member_count, total_xp, month_pt, house_lv))
+    ordered.sort(key=lambda x: (-x[4], -x[3]))
+
+    for i, (house_id, member_count, total_xp, month_pt, house_lv) in enumerate(ordered, start=1):
+        h_name: str = _house_name(house_id)
+        h_emoji: str = _house_emoji(house_id)
+        cur_xp: int = required_xp_for_level(house_lv, CONTRIBUTION_HOUSE_LEVEL_COEF, CONTRIBUTION_HOUSE_LEVEL_EXP)
+        next_xp: int = required_xp_for_level(house_lv + 1, CONTRIBUTION_HOUSE_LEVEL_COEF, CONTRIBUTION_HOUSE_LEVEL_EXP)
+        in_lv: int = total_xp - cur_xp
+        span: int = max(1, next_xp - cur_xp)
+        bar_filled: int = max(0, min(10, round((in_lv / span) * 10)))
+        bar: str = "▰" * bar_filled + "▱" * (10 - bar_filled)
+        embed.add_field(
+            name=f"`#{i}` {h_emoji} {h_name}  ・ 寮Lv {house_lv}",
+            value=(
+                f"{bar} {_fmt_int(in_lv)}/{_fmt_int(next_xp - cur_xp)} XP\n"
+                f"累積 **{_fmt_int(total_xp)} XP** ・ 今月 **{_fmt_int(month_pt)} pt** ・ メンバー {member_count}人"
+            ),
+            inline=False,
+        )
+
+    embed.set_footer(text="Webダッシュボード: https://pubview-dashboard.pages.dev/")
+    await ctx.respond(embed=embed)
+# -----------------------------
+
+
 @bot.slash_command(name="ranking", description="サーバー内のLoLランクランキングを表示します。", guild_ids=[DISCORD_GUILD_ID])
 async def ranking(ctx: discord.ApplicationContext) -> None:
     await ctx.defer()

--- a/main.py
+++ b/main.py
@@ -317,15 +317,31 @@ async def notify_level_up(discord_id: int, old_level: int, new_level: int) -> No
     if new_level - old_level >= 2:
         title = f"🎉🎉 {new_level - old_level}連Lv UP!"
 
+    # 個人ページURL（display_name 経由）。失敗時はトップにフォールバック
+    user_page_url: str = "https://pubview-dashboard.pages.dev/"
+    try:
+        guild_for_member: discord.Guild | None = bot.get_guild(DISCORD_GUILD_ID)
+        member_obj: discord.Member | None = None
+        if guild_for_member is not None:
+            member_obj = guild_for_member.get_member(discord_id)
+            if member_obj is None:
+                member_obj = await guild_for_member.fetch_member(discord_id)
+        if member_obj is not None:
+            import urllib.parse as _up
+            user_page_url = f"https://pubview-dashboard.pages.dev/u/{_up.quote(member_obj.display_name, safe='')}"
+    except Exception:
+        pass
+
     embed: discord.Embed = discord.Embed(
         title=title,
+        url=user_page_url,
         description=f"<@{discord_id}> さんが **Lv {new_level}** に到達しました！",
         color=discord.Color.gold(),
     )
     embed.add_field(name="所属", value=f"{house_emoji} {house_name_jp}", inline=True)
     embed.add_field(name="現在", value=f"Lv {new_level}", inline=True)
     embed.add_field(name=f"次Lv {new_level + 1} まで", value=f"あと **{remaining:,} XP**（{in_lv:,}/{span:,}）", inline=False)
-    embed.set_footer(text="Webダッシュボード: https://pubview-dashboard.pages.dev/")
+    embed.add_field(name="​", value=f"[📊 ダッシュボードで詳細を見る →]({user_page_url})", inline=False)
     try:
         await channel.send(
             embed=embed,
@@ -1164,13 +1180,15 @@ async def leaderboard(
             f"`#{i:>2}` {_house_emoji(house_id)} {member_name} ・ Lv {lv} ・ **{_fmt_int(value)} {primary_label}**"
         )
 
+    dashboard_lb_url: str = f"https://pubview-dashboard.pages.dev/leaderboard?mode={mode}"
     embed.description = "\n".join(lines)
-    embed.set_footer(
-        text=(
-            "mode=total: 累積XP順 / mode=monthly: 今月pt順"
-            f"\nWebダッシュボード: https://pubview-dashboard.pages.dev/"
-        )
+    embed.url = dashboard_lb_url
+    embed.add_field(
+        name="​",
+        value=f"[📊 Webダッシュボードのランキングを開く →]({dashboard_lb_url})",
+        inline=False,
     )
+    embed.set_footer(text="mode=total: 累積XP順 / mode=monthly: 今月pt順")
     await ctx.respond(embed=embed)
 
 
@@ -1236,7 +1254,12 @@ async def house_standings(ctx: discord.ApplicationContext) -> None:
             inline=False,
         )
 
-    embed.set_footer(text="Webダッシュボード: https://pubview-dashboard.pages.dev/")
+    embed.url = "https://pubview-dashboard.pages.dev/"
+    embed.add_field(
+        name="​",
+        value="[📊 Webダッシュボードを開く →](https://pubview-dashboard.pages.dev/)",
+        inline=False,
+    )
     await ctx.respond(embed=embed)
 # -----------------------------
 
@@ -1852,8 +1875,10 @@ async def post_weekly_digest_for_house(house_id: str) -> str:
         rank_line = f"🏃 順位: 4寮中 {rank}位 / 1位{HOUSE_BY_ID[standings[0][0]][1]}まで +{leader_pt - house_gained:,} pt"
 
     desc: str = "\n".join(kpi_lines)
+    house_page_url: str = f"https://pubview-dashboard.pages.dev/houses/{house_id}"
     embed: discord.Embed = discord.Embed(
         title=f"{house_emoji} {house_name_jp} 週次ダイジェスト",
+        url=house_page_url,
         description=(
             f"📅 {this_monday.strftime('%Y年%m月%d日')} 〜 {this_sunday.strftime('%Y年%m月%d日')}\n\n"
             f"📊 主要指標 (KPIs)\n{desc}"
@@ -1866,7 +1891,11 @@ async def post_weekly_digest_for_house(house_id: str) -> str:
         embed.add_field(name="🏆 トップコントリビューター", value="\n\n".join(top_lines)[:1024], inline=False)
     if rank_line:
         embed.add_field(name="📈 トレンド", value=rank_line, inline=False)
-    embed.set_footer(text=f"Webダッシュボード: {DASHBOARD_URL}")
+    embed.add_field(
+        name="​",
+        value=f"[📊 {house_name_jp} の寮ページを見る →]({house_page_url})",
+        inline=False,
+    )
     try:
         await channel.send(
             embed=embed,
@@ -1947,8 +1976,10 @@ async def post_monthly_summary(year_month_override: str | None = None) -> str:
             house_emoji: str = HOUSE_BY_ID[hid][2]
             mvp_lines.append(f"`#{i}` {house_emoji} <@{did}> — **{pt:,} pt**")
 
+    monthly_page_url: str = f"https://pubview-dashboard.pages.dev/monthly/{target_ym}"
     embed: discord.Embed = discord.Embed(
         title=f"📅 {target_ym} 月次サマリ",
+        url=monthly_page_url,
         color=discord.Color.gold(),
     )
     embed.add_field(
@@ -1961,7 +1992,11 @@ async def post_monthly_summary(year_month_override: str | None = None) -> str:
         value="\n".join(mvp_lines) if mvp_lines else "（記録なし）",
         inline=False,
     )
-    embed.set_footer(text=f"Webダッシュボード: {DASHBOARD_URL}")
+    embed.add_field(
+        name="​",
+        value=f"[📊 {target_ym} のアーカイブを見る →]({monthly_page_url})",
+        inline=False,
+    )
     try:
         await channel.send(
             embed=embed,

--- a/main.py
+++ b/main.py
@@ -59,6 +59,24 @@ RATE_BRACKET_OF_TIER: dict[str, str] = {
 }
 # ----------------
 
+# --- コントリビューション機能の設定 ---
+# ポイント発生源（バランス調整時はここを変更）
+CONTRIBUTION_VC_PT_PER_MINUTE: int = 1
+CONTRIBUTION_TEXT_PT_PER_MESSAGE: int = 2
+CONTRIBUTION_TEXT_COOLDOWN_SECONDS: int = 60
+
+# レベル式: 累積XP = COEF * level^EXP に達したら次のレベル
+# 個人:  Lv N 必要累積XP = 20 * N^2   （Lv50 ≈ 50,000 XP）
+# 寮:    Lv N 必要累積XP = 300 * N^2  （個人式の15倍重い、特典設計用に長期目標化）
+CONTRIBUTION_USER_LEVEL_COEF: int = 20
+CONTRIBUTION_USER_LEVEL_EXP: float = 2.0
+CONTRIBUTION_HOUSE_LEVEL_COEF: int = 300
+CONTRIBUTION_HOUSE_LEVEL_EXP: float = 2.0
+# -----------------------------
+
+# JST（モジュール全体で共用）
+jst: datetime.timezone = datetime.timezone(datetime.timedelta(hours=9))
+
 # --- データベースの初期設定 ---
 def setup_database() -> None:
     os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
@@ -92,8 +110,148 @@ def setup_database() -> None:
             sorted_at TEXT NOT NULL
         )
     ''')
+    # コントリビューション: 個人累積（永続）
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS contribution_totals (
+            discord_id INTEGER PRIMARY KEY,
+            total_xp INTEGER NOT NULL DEFAULT 0,
+            vc_seconds INTEGER NOT NULL DEFAULT 0,
+            text_messages INTEGER NOT NULL DEFAULT 0,
+            last_text_at TEXT,
+            updated_at TEXT NOT NULL
+        )
+    ''')
+    # コントリビューション: 月次集計（JST月初リセット相当、年月キーで分離）
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS contribution_monthly (
+            year_month TEXT NOT NULL,
+            discord_id INTEGER NOT NULL,
+            points INTEGER NOT NULL DEFAULT 0,
+            vc_seconds INTEGER NOT NULL DEFAULT 0,
+            text_messages INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (year_month, discord_id)
+        )
+    ''')
+    # コントリビューション: VC在室セッション（joinで記録、leaveで秒数確定→totals/monthly加算）
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS vc_sessions (
+            discord_id INTEGER PRIMARY KEY,
+            channel_id INTEGER NOT NULL,
+            joined_at TEXT NOT NULL
+        )
+    ''')
     con.commit()
     con.close()
+# -----------------------------
+
+# --- コントリビューション機能のヘルパー ---
+def is_sorted(discord_id: int) -> bool:
+    """組分け帽子を被ったメンバーかどうか"""
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute("SELECT 1 FROM sorting_hat WHERE discord_id = ?", (discord_id,))
+    found: bool = cur.fetchone() is not None
+    con.close()
+    return found
+
+
+def current_year_month_jst() -> str:
+    """JST基準の '%Y-%m' 文字列。月次集計のキーに使用"""
+    return datetime.datetime.now(jst).strftime("%Y-%m")
+
+
+def required_xp_for_level(level: int, coef: int = CONTRIBUTION_USER_LEVEL_COEF, exp: float = CONTRIBUTION_USER_LEVEL_EXP) -> int:
+    """指定レベルに到達するために必要な累積XP（Lv1は0XP）"""
+    if level <= 1:
+        return 0
+    return int(coef * (level ** exp))
+
+
+def level_from_xp(xp: int, coef: int = CONTRIBUTION_USER_LEVEL_COEF, exp: float = CONTRIBUTION_USER_LEVEL_EXP) -> int:
+    """累積XPからレベルを算出。Lv N 必要XP = coef * N^exp の逆算"""
+    if xp <= 0:
+        return 1
+    raw_level: float = (xp / coef) ** (1.0 / exp)
+    return max(1, int(raw_level))
+
+
+def add_contribution(discord_id: int, xp: int, vc_seconds: int, text_messages: int, last_text_at_iso: str | None = None) -> None:
+    """totals と monthly に同時加算。組分け済みであることは呼び出し側で保証する。"""
+    if xp == 0 and vc_seconds == 0 and text_messages == 0:
+        return
+    now_iso: str = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    ym: str = current_year_month_jst()
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    # totals
+    cur.execute(
+        """
+        INSERT INTO contribution_totals (discord_id, total_xp, vc_seconds, text_messages, last_text_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(discord_id) DO UPDATE SET
+            total_xp = total_xp + excluded.total_xp,
+            vc_seconds = vc_seconds + excluded.vc_seconds,
+            text_messages = text_messages + excluded.text_messages,
+            last_text_at = COALESCE(excluded.last_text_at, contribution_totals.last_text_at),
+            updated_at = excluded.updated_at
+        """,
+        (discord_id, xp, vc_seconds, text_messages, last_text_at_iso, now_iso),
+    )
+    # monthly
+    cur.execute(
+        """
+        INSERT INTO contribution_monthly (year_month, discord_id, points, vc_seconds, text_messages)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(year_month, discord_id) DO UPDATE SET
+            points = points + excluded.points,
+            vc_seconds = vc_seconds + excluded.vc_seconds,
+            text_messages = text_messages + excluded.text_messages
+        """,
+        (ym, discord_id, xp, vc_seconds, text_messages),
+    )
+    con.commit()
+    con.close()
+
+
+def vc_session_start(discord_id: int, channel_id: int) -> None:
+    """VC参加を記録。組分け済みのみ実行する想定（呼び出し側でフィルタ）"""
+    now_iso: str = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute(
+        "INSERT OR REPLACE INTO vc_sessions (discord_id, channel_id, joined_at) VALUES (?, ?, ?)",
+        (discord_id, channel_id, now_iso),
+    )
+    con.commit()
+    con.close()
+
+
+def vc_session_end(discord_id: int) -> int:
+    """VC退出時に在室秒数を確定し、totals/monthly へ加算。在室秒数を返す。"""
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute("SELECT joined_at FROM vc_sessions WHERE discord_id = ?", (discord_id,))
+    row: tuple[str] | None = cur.fetchone()
+    if not row:
+        con.close()
+        return 0
+    try:
+        joined_at: datetime.datetime = datetime.datetime.fromisoformat(row[0])
+    except ValueError:
+        cur.execute("DELETE FROM vc_sessions WHERE discord_id = ?", (discord_id,))
+        con.commit()
+        con.close()
+        return 0
+    now_utc: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
+    seconds: int = max(0, int((now_utc - joined_at).total_seconds()))
+    cur.execute("DELETE FROM vc_sessions WHERE discord_id = ?", (discord_id,))
+    con.commit()
+    con.close()
+    if seconds > 0:
+        # 分単位で切り捨て、端数秒は次回まわし（vc_secondsは秒で記録）
+        added_xp: int = (seconds // 60) * CONTRIBUTION_VC_PT_PER_MINUTE
+        add_contribution(discord_id, xp=added_xp, vc_seconds=seconds, text_messages=0)
+    return seconds
 # -----------------------------
 
 # --- Botの初期設定 ---
@@ -584,6 +742,19 @@ async def on_ready() -> None:
 
     # Bot起動時に永続Viewを登録
     bot.add_view(DashboardView())
+
+    # --- コントリビューション: 起動時のVC在室者スキャン ---
+    # 再起動を跨いで在室している組分け済みメンバーを vc_sessions に再登録する
+    # （再起動中の時間はロストする。今この瞬間からの計測再開）
+    for guild in bot.guilds:
+        for vc in guild.voice_channels:
+            for vc_member in vc.members:
+                if vc_member.bot:
+                    continue
+                if is_sorted(vc_member.id):
+                    vc_session_start(vc_member.id, vc.id)
+    print("--- VC sessions re-initialized for sorted members ---")
+
     # 起動時ランキング速報は一旦停止（再開する場合は下記ブロックを有効化）
     # print("--- Posting initial ranking on startup ---")
     # channel: discord.TextChannel | discord.VoiceChannel | discord.Thread | None = bot.get_channel(NOTIFICATION_CHANNEL_ID)
@@ -683,6 +854,79 @@ async def unregister(ctx: discord.ApplicationContext) -> None:
 
     except Exception as e:
         await ctx.respond("登録解除中に予期せぬエラーが発生しました。")
+
+@bot.slash_command(name="score", description="あなたの貢献度・レベル・今月のポイントを表示します。", guild_ids=[DISCORD_GUILD_ID])
+async def score(ctx: discord.ApplicationContext) -> None:
+    await ctx.defer(ephemeral=True)
+    discord_id: int = ctx.author.id
+
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute("SELECT house_id FROM sorting_hat WHERE discord_id = ?", (discord_id,))
+    house_row: tuple[str] | None = cur.fetchone()
+    if not house_row:
+        con.close()
+        await ctx.respond(
+            "まだ組分け帽子を被っていません。ダッシュボードから組分けすると貢献度が貯まり始めます。",
+            ephemeral=True,
+        )
+        return
+    house_info: tuple[str, str, str, str] | None = next((h for h in HOUSES if h[0] == house_row[0]), None)
+
+    cur.execute(
+        "SELECT total_xp, vc_seconds, text_messages FROM contribution_totals WHERE discord_id = ?",
+        (discord_id,),
+    )
+    totals_row: tuple[int, int, int] | None = cur.fetchone()
+    total_xp: int = totals_row[0] if totals_row else 0
+    vc_seconds: int = totals_row[1] if totals_row else 0
+    text_messages: int = totals_row[2] if totals_row else 0
+
+    ym: str = current_year_month_jst()
+    cur.execute(
+        "SELECT points, vc_seconds, text_messages FROM contribution_monthly WHERE year_month = ? AND discord_id = ?",
+        (ym, discord_id),
+    )
+    monthly_row: tuple[int, int, int] | None = cur.fetchone()
+    monthly_pt: int = monthly_row[0] if monthly_row else 0
+    monthly_vc: int = monthly_row[1] if monthly_row else 0
+    monthly_text: int = monthly_row[2] if monthly_row else 0
+    con.close()
+
+    level: int = level_from_xp(total_xp)
+    current_level_xp: int = required_xp_for_level(level)
+    next_level_xp: int = required_xp_for_level(level + 1)
+    xp_into_current: int = total_xp - current_level_xp
+    xp_needed: int = next_level_xp - current_level_xp
+
+    embed: discord.Embed = discord.Embed(
+        title=f"📊 {ctx.author.display_name} の貢献度",
+        color=discord.Color.blurple(),
+    )
+    if house_info:
+        embed.add_field(name="所属", value=f"{house_info[2]} {house_info[1]}", inline=False)
+    embed.add_field(name="個人レベル", value=f"Lv {level}", inline=True)
+    embed.add_field(name="累積XP", value=f"{total_xp:,}", inline=True)
+    embed.add_field(name="次Lvまで", value=f"{xp_into_current:,} / {xp_needed:,} XP", inline=True)
+    embed.add_field(
+        name=f"今月（{ym}）",
+        value=(
+            f"**{monthly_pt:,} pt**\n"
+            f"VC {monthly_vc // 3600}時間{(monthly_vc % 3600) // 60}分 / "
+            f"投稿 {monthly_text:,}件"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="累積アクティビティ",
+        value=(
+            f"VC {vc_seconds // 3600}時間{(vc_seconds % 3600) // 60}分 / "
+            f"投稿 {text_messages:,}件"
+        ),
+        inline=False,
+    )
+    await ctx.respond(embed=embed, ephemeral=True)
+
 
 @bot.slash_command(name="ranking", description="サーバー内のLoLランクランキングを表示します。", guild_ids=[DISCORD_GUILD_ID])
 async def ranking(ctx: discord.ApplicationContext) -> None:
@@ -846,7 +1090,6 @@ async def debug_modify_rank(ctx: discord.ApplicationContext, user: discord.Membe
         await ctx.respond(f"処理中にエラーが発生しました: {e}")
 
 # --- バックグラウンドタスク ---
-jst: datetime.timezone = datetime.timezone(datetime.timedelta(hours=9))
 @tasks.loop(time=datetime.time(hour=12, minute=0, tzinfo=jst))
 async def check_ranks_periodically() -> None:
     print("--- Starting periodic rank check ---")
@@ -949,7 +1192,48 @@ async def check_ranks_periodically() -> None:
     print("--- Periodic rank check finished ---")
 
 @bot.event
+async def on_message(message: discord.Message) -> None:
+    # Bot自身・DM・システムメッセージは除外
+    if message.author.bot or message.guild is None:
+        return
+    discord_id: int = message.author.id
+    if not is_sorted(discord_id):
+        return
+    # 60秒クールダウン判定
+    now_utc: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    cur.execute("SELECT last_text_at FROM contribution_totals WHERE discord_id = ?", (discord_id,))
+    row: tuple[str | None] | None = cur.fetchone()
+    con.close()
+    if row and row[0]:
+        try:
+            last_at: datetime.datetime = datetime.datetime.fromisoformat(row[0])
+            if (now_utc - last_at).total_seconds() < CONTRIBUTION_TEXT_COOLDOWN_SECONDS:
+                return
+        except ValueError:
+            pass
+    add_contribution(
+        discord_id,
+        xp=CONTRIBUTION_TEXT_PT_PER_MESSAGE,
+        vc_seconds=0,
+        text_messages=1,
+        last_text_at_iso=now_utc.isoformat(),
+    )
+
+
+@bot.event
 async def on_voice_state_update(member: discord.Member, before: discord.VoiceState, after: discord.VoiceState) -> None:
+    # --- コントリビューション: VC在室秒数の計測 ---
+    # チャンネルが変わったとき（join / leave / move）のみ処理
+    if not member.bot and before.channel != after.channel:
+        # 旧セッションを確定（退出 or 移動元）
+        if before.channel is not None:
+            vc_session_end(member.id)
+        # 新セッション開始（入室 or 移動先）。組分け済みのみ計測対象
+        if after.channel is not None and is_sorted(member.id):
+            vc_session_start(member.id, after.channel.id)
+
     guild: discord.Guild = member.guild
     category: discord.CategoryChannel | None = discord.utils.get(guild.categories, id=1469467787356410030)
 

--- a/main.py
+++ b/main.py
@@ -140,6 +140,16 @@ def setup_database() -> None:
             joined_at TEXT NOT NULL
         )
     ''')
+    # 寮ごとのDiscordチャンネルID（/setup_house_channels で作成・記録）
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS house_channels (
+            house_id     TEXT NOT NULL,
+            channel_type TEXT NOT NULL,
+            channel_id   INTEGER NOT NULL,
+            created_at   TEXT NOT NULL,
+            PRIMARY KEY (house_id, channel_type)
+        )
+    ''')
     con.commit()
     con.close()
 # -----------------------------
@@ -966,6 +976,131 @@ async def dashboard(ctx: discord.ApplicationContext, channel: discord.TextChanne
 
     await target_channel.send(embed=embed, view=DashboardView())
     await ctx.respond("ダッシュボードを送信しました。", ephemeral=True)
+
+@bot.slash_command(name="setup_house_channels", description="4寮ぶんのカテゴリ・チャンネルを一括作成します。（管理者向け）", guild_ids=[DISCORD_GUILD_ID])
+@discord.default_permissions(administrator=True)
+async def setup_house_channels(ctx: discord.ApplicationContext) -> None:
+    """寮ごとのカテゴリと配下チャンネル（雑談/リーダーボード/VC）を一括作成する。
+
+    権限設計:
+      - カテゴリ: @everyone view denied / 寮ロール view allowed
+      - 雑談 / VC: カテゴリから継承
+      - リーダーボード: カテゴリから継承 + 寮ロール send_messages denied（Botのみ投稿可）
+
+    idempotent: 既に作成済みのチャンネルがあればスキップ、無いものだけ作る。
+    作成結果は house_channels テーブルに記録する。
+    """
+    await ctx.defer(ephemeral=True)
+    guild: discord.Guild | None = ctx.guild
+    if guild is None:
+        await ctx.respond("ギルド情報が取得できませんでした。", ephemeral=True)
+        return
+
+    me: discord.Member | None = guild.me
+    bot_member: discord.Member = me if me is not None else await guild.fetch_member(bot.user.id)
+
+    con: sqlite3.Connection = sqlite3.connect(DB_PATH)
+    cur: sqlite3.Cursor = con.cursor()
+    now_iso: str = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    summary_lines: list[str] = []
+
+    for house_id, house_name_jp, house_emoji, role_name in HOUSES:
+        house_role: discord.Role | None = discord.utils.get(guild.roles, name=role_name)
+        if house_role is None:
+            summary_lines.append(f"⚠️ {house_emoji} {house_name_jp}: ロール「{role_name}」が見つかりません。先にロール作成が必要。")
+            continue
+
+        # カテゴリ権限: @everyone view denied / 寮ロール view allowed / Bot view allowed
+        category_overwrites: dict[discord.Role | discord.Member, discord.PermissionOverwrite] = {
+            guild.default_role: discord.PermissionOverwrite(view_channel=False),
+            house_role:          discord.PermissionOverwrite(view_channel=True, connect=True),
+            bot_member:          discord.PermissionOverwrite(view_channel=True, send_messages=True, manage_channels=True, connect=True),
+        }
+
+        category_name: str = f"{house_emoji}｜{house_name_jp}"
+        category: discord.CategoryChannel | None = discord.utils.get(guild.categories, name=category_name)
+        category_created: bool = False
+        if category is None:
+            try:
+                category = await guild.create_category(name=category_name, overwrites=category_overwrites, reason=f"setup_house_channels: {house_id}")
+                category_created = True
+            except Exception as e:
+                summary_lines.append(f"❌ {house_emoji} {house_name_jp}: カテゴリ作成失敗 ({e})")
+                continue
+        else:
+            # 既存カテゴリの権限を念のため上書き（誤設定リカバリ）
+            try:
+                for target, ow in category_overwrites.items():
+                    await category.set_permissions(target, overwrite=ow, reason="setup_house_channels: enforce overwrites")
+            except Exception as e:
+                print(f"!!! setup_house_channels: failed to enforce category overwrites for {house_id}: {e}")
+
+        cur.execute(
+            "INSERT OR REPLACE INTO house_channels (house_id, channel_type, channel_id, created_at) VALUES (?, ?, ?, ?)",
+            (house_id, "category", category.id, now_iso),
+        )
+
+        # 配下チャンネル定義: (channel_type, name, kind, extra_overwrites)
+        # kind: "text" | "voice"
+        # extra_overwrites: リーダーボードは寮ロールに send_messages = False を上書き
+        chat_name: str = "雑談"
+        board_name: str = "リーダーボード"
+        vc_name: str = f"{house_name_jp}VC"
+
+        # リーダーボード用 overwrite（カテゴリ継承 + 寮ロールの send 拒否）
+        board_overwrites: dict[discord.Role | discord.Member, discord.PermissionOverwrite] = {
+            guild.default_role: discord.PermissionOverwrite(view_channel=False),
+            house_role:          discord.PermissionOverwrite(view_channel=True, send_messages=False, add_reactions=True),
+            bot_member:          discord.PermissionOverwrite(view_channel=True, send_messages=True, manage_messages=True),
+        }
+
+        sub_channels: list[tuple[str, str, str, dict[discord.Role | discord.Member, discord.PermissionOverwrite] | None]] = [
+            ("chat",        chat_name,  "text",  None),
+            ("leaderboard", board_name, "text",  board_overwrites),
+            ("vc",          vc_name,    "voice", None),
+        ]
+
+        for channel_type, name, kind, extra_ow in sub_channels:
+            existing: discord.abc.GuildChannel | None
+            if kind == "text":
+                existing = discord.utils.get(category.text_channels, name=name)
+            else:
+                existing = discord.utils.get(category.voice_channels, name=name)
+            if existing is not None:
+                cur.execute(
+                    "INSERT OR REPLACE INTO house_channels (house_id, channel_type, channel_id, created_at) VALUES (?, ?, ?, ?)",
+                    (house_id, channel_type, existing.id, now_iso),
+                )
+                continue
+            try:
+                if kind == "text":
+                    created = await guild.create_text_channel(
+                        name=name, category=category,
+                        overwrites=extra_ow if extra_ow is not None else category_overwrites,
+                        reason=f"setup_house_channels: {house_id}/{channel_type}",
+                    )
+                else:
+                    created = await guild.create_voice_channel(
+                        name=name, category=category, user_limit=0,
+                        reason=f"setup_house_channels: {house_id}/{channel_type}",
+                    )
+                cur.execute(
+                    "INSERT OR REPLACE INTO house_channels (house_id, channel_type, channel_id, created_at) VALUES (?, ?, ?, ?)",
+                    (house_id, channel_type, created.id, now_iso),
+                )
+            except Exception as e:
+                summary_lines.append(f"❌ {house_emoji} {house_name_jp}/{name}: 作成失敗 ({e})")
+
+        summary_lines.append(
+            f"{'🆕' if category_created else '♻️'} {house_emoji} {house_name_jp}: カテゴリ + 雑談 + リーダーボード + VC OK"
+        )
+
+    con.commit()
+    con.close()
+
+    msg: str = "**寮チャンネルセットアップ完了**\n" + "\n".join(summary_lines)
+    await ctx.respond(msg, ephemeral=True)
 
 @bot.slash_command(name="add_section", description="参加可能なセクションを登録します。（管理者向け）", guild_ids=[DISCORD_GUILD_ID])
 @discord.default_permissions(administrator=True)

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ NOTIFICATION_CHANNEL_ID: int = 1401719055643312219 # 通知用チャンネルID
 HONOR_CHANNEL_ID: int = 1447166222591594607 # 名誉用チャンネルID
 VOICE_CREATE_CHANNEL_ID: int = 1469467862358823125
 RANK_GAME_CHANNEL_ID: int = 1470346492895166566
+AFK_CHANNEL_ID: int = 1396150541608026303  # 寝落ち/AFK 用VC、コントリビューション計測対象外
 RANK_ROLES: dict[str, str] = {
     "IRON": "LoL Iron(Solo/Duo)", "BRONZE": "LoL Bronze(Solo/Duo)", "SILVER": "LoL Silver(Solo/Duo)",
     "GOLD": "LoL Gold(Solo/Duo)", "PLATINUM": "LoL Platinum(Solo/Duo)", "EMERALD": "LoL Emerald(Solo/Duo)",
@@ -899,14 +900,17 @@ async def on_ready() -> None:
     # --- コントリビューション: 起動時のVC在室者スキャン ---
     # 再起動を跨いで在室している組分け済みメンバーを vc_sessions に再登録する
     # （再起動中の時間はロストする。今この瞬間からの計測再開）
+    # AFK チャンネルは計測対象外
     for guild in bot.guilds:
         for vc in guild.voice_channels:
+            if vc.id == AFK_CHANNEL_ID:
+                continue
             for vc_member in vc.members:
                 if vc_member.bot:
                     continue
                 if is_sorted(vc_member.id):
                     vc_session_start(vc_member.id, vc.id)
-    print("--- VC sessions re-initialized for sorted members ---")
+    print("--- VC sessions re-initialized for sorted members (AFK excluded) ---")
 
     # 起動時ランキング速報は一旦停止（再開する場合は下記ブロックを有効化）
     # print("--- Posting initial ranking on startup ---")
@@ -2454,13 +2458,13 @@ async def on_voice_state_update(member: discord.Member, before: discord.VoiceSta
     # --- コントリビューション: VC在室秒数の計測 ---
     # チャンネルが変わったとき（join / leave / move）のみ処理
     if not member.bot and before.channel != after.channel:
-        # 旧セッションを確定（退出 or 移動元）
+        # 旧セッションを確定（退出 or 移動元）。AFKチャンネルからの移動は session 自体が無いので no-op
         if before.channel is not None:
             old_level, new_level = vc_session_end(member.id)
             if new_level > old_level:
                 await notify_level_up(member.id, old_level, new_level)
-        # 新セッション開始（入室 or 移動先）。組分け済みのみ計測対象
-        if after.channel is not None and is_sorted(member.id):
+        # 新セッション開始（入室 or 移動先）。組分け済みかつ AFK 以外のみ計測対象
+        if after.channel is not None and after.channel.id != AFK_CHANNEL_ID and is_sorted(member.id):
             vc_session_start(member.id, after.channel.id)
 
     guild: discord.Guild = member.guild

--- a/web/.dev.vars.example
+++ b/web/.dev.vars.example
@@ -1,0 +1,3 @@
+# Bot からの同期に使う共有シークレット
+# 本番は wrangler pages secret put INGEST_TOKEN で登録すること
+INGEST_TOKEN=replace-with-64char-random-string

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,47 @@
+# pubview-dashboard (Web)
+
+Astro + Cloudflare Pages + D1 で稼働する、ぱぶびゅ！コントリビューションダッシュボード。
+
+## 構成
+
+- **Frontend**: Astro v5 (SSR) + Tailwind v3
+- **Hosting**: Cloudflare Pages
+- **DB**: Cloudflare D1 (`pubview-dashboard-db`)
+- **同期元**: macmini 上の Bot が5分おきに `/api/ingest` へ POST
+
+## ローカル開発
+
+```bash
+pnpm install
+cp .dev.vars.example .dev.vars   # INGEST_TOKEN を本物に差し替え
+pnpm d1:apply:local              # ローカル D1 にスキーマ適用
+pnpm dev                         # http://localhost:4321
+```
+
+## デプロイ
+
+```bash
+# 本番 D1 にマイグレーション適用
+pnpm d1:apply
+
+# Pages にデプロイ
+pnpm deploy
+
+# シークレット登録（初回のみ）
+wrangler pages secret put INGEST_TOKEN --project-name pubview-dashboard
+```
+
+## URL（予定）
+
+| パス | 役割 |
+|---|---|
+| `/` | 4寮の対決ボード |
+| `/houses/[house_id]` | 寮詳細（メンバー一覧、推移グラフ） |
+| `/leaderboard` | 全体ランキング（累積/月次切替） |
+| `/u/[slug]` | 個人ページ |
+| `/monthly/[yyyy-mm]` | 月次アーカイブ |
+| `/api/ingest` | Bot からの同期受信エンドポイント（POST） |
+
+## アクセス制御
+
+現状はパブリック（`robots.txt` で noindex）。将来 Discord OAuth を入れる際は `feature/oauth` で追加予定。

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  output: 'server',
+  adapter: cloudflare({
+    platformProxy: { enabled: true },
+  }),
+  integrations: [tailwind()],
+});

--- a/web/migrations/0001_init.sql
+++ b/web/migrations/0001_init.sql
@@ -1,0 +1,58 @@
+-- pubview-dashboard 初期スキーマ
+-- Bot側 SQLite (Docker内 /data/lol_bot.db) からの同期先
+
+-- ユーザー: Discordプロフィール + Riot ID（Bot側 users + Discordから補完）
+CREATE TABLE IF NOT EXISTS users (
+  discord_id     TEXT PRIMARY KEY,
+  display_name   TEXT NOT NULL,
+  avatar_url     TEXT,
+  riot_game_name TEXT,
+  riot_tag_line  TEXT,
+  tier           TEXT,
+  rank           TEXT,
+  league_points  INTEGER,
+  updated_at     TEXT NOT NULL
+);
+
+-- 組分け帽子
+CREATE TABLE IF NOT EXISTS sorting_hat (
+  discord_id   TEXT PRIMARY KEY,
+  house_id     TEXT NOT NULL,
+  rate_bracket TEXT NOT NULL,
+  tier         TEXT NOT NULL,
+  sorted_at    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sorting_hat_house ON sorting_hat(house_id);
+
+-- 個人累積（永続）
+CREATE TABLE IF NOT EXISTS contribution_totals (
+  discord_id    TEXT PRIMARY KEY,
+  total_xp      INTEGER NOT NULL DEFAULT 0,
+  vc_seconds    INTEGER NOT NULL DEFAULT 0,
+  text_messages INTEGER NOT NULL DEFAULT 0,
+  updated_at    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_totals_xp ON contribution_totals(total_xp DESC);
+
+-- 月次集計
+CREATE TABLE IF NOT EXISTS contribution_monthly (
+  year_month    TEXT NOT NULL,
+  discord_id    TEXT NOT NULL,
+  points        INTEGER NOT NULL DEFAULT 0,
+  vc_seconds    INTEGER NOT NULL DEFAULT 0,
+  text_messages INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (year_month, discord_id)
+);
+CREATE INDEX IF NOT EXISTS idx_monthly_points ON contribution_monthly(year_month, points DESC);
+
+-- 同期ログ（直近の取り込み状況の可視化用）
+CREATE TABLE IF NOT EXISTS ingest_log (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  ingested_at     TEXT NOT NULL,
+  users_count     INTEGER NOT NULL,
+  sorting_count   INTEGER NOT NULL,
+  totals_count    INTEGER NOT NULL,
+  monthly_count   INTEGER NOT NULL,
+  bot_version     TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ingest_log_at ON ingest_log(ingested_at DESC);

--- a/web/migrations/0002_house_leaders.sql
+++ b/web/migrations/0002_house_leaders.sql
@@ -1,0 +1,7 @@
+-- 寮長: 管理者が手動で任命する。Bot DBで一意に管理し同期される
+CREATE TABLE IF NOT EXISTS house_leaders (
+  house_id   TEXT PRIMARY KEY,
+  discord_id TEXT NOT NULL,
+  set_at     TEXT NOT NULL,
+  set_by     TEXT
+);

--- a/web/migrations/0003_daily_snapshots.sql
+++ b/web/migrations/0003_daily_snapshots.sql
@@ -1,0 +1,10 @@
+-- 日次スナップショット: 個人ページの「日次成果グラフ」描画に使う
+CREATE TABLE IF NOT EXISTS daily_snapshots (
+  snapshot_date  TEXT    NOT NULL,
+  discord_id     TEXT    NOT NULL,
+  total_xp       INTEGER NOT NULL DEFAULT 0,
+  vc_seconds     INTEGER NOT NULL DEFAULT 0,
+  text_messages  INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (snapshot_date, discord_id)
+);
+CREATE INDEX IF NOT EXISTS idx_daily_snapshots_user ON daily_snapshots(discord_id, snapshot_date DESC);

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "pubview-dashboard",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "wrangler pages dev ./dist",
+    "deploy": "astro build && wrangler pages deploy ./dist --project-name pubview-dashboard",
+    "d1:apply": "wrangler d1 migrations apply pubview-dashboard-db --remote",
+    "d1:apply:local": "wrangler d1 migrations apply pubview-dashboard-db --local",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/cloudflare": "^12.5.0",
+    "@astrojs/tailwind": "^6.0.0",
+    "astro": "^5.7.0",
+    "tailwindcss": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,0 +1,5029 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: ^12.5.0
+        version: 12.6.13(@types/node@22.19.19)(astro@5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(yaml@2.9.0)
+      '@astrojs/tailwind':
+        specifier: ^6.0.0
+        version: 6.0.2(astro@5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(yaml@2.9.0))
+      astro:
+        specifier: ^5.7.0
+        version: 5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0)
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.19(yaml@2.9.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.19
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      wrangler:
+        specifier: ^4.0.0
+        version: 4.90.1(@cloudflare/workers-types@4.20260511.1)
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@astrojs/cloudflare@12.6.13':
+    resolution: {integrity: sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==}
+    peerDependencies:
+      astro: ^5.7.0
+
+  '@astrojs/compiler@2.13.1':
+    resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
+
+  '@astrojs/internal-helpers@0.7.6':
+    resolution: {integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==}
+
+  '@astrojs/markdown-remark@6.3.11':
+    resolution: {integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==}
+
+  '@astrojs/prism@3.3.0':
+    resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/tailwind@6.0.2':
+    resolution: {integrity: sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg==}
+    peerDependencies:
+      astro: ^3.0.0 || ^4.0.0 || ^5.0.0
+      tailwindcss: ^3.0.24
+
+  '@astrojs/telemetry@3.3.0':
+    resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/underscore-redirects@1.0.0':
+    resolution: {integrity: sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@capsizecss/unpack@4.0.0':
+    resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
+    engines: {node: '>=18'}
+
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.10.0':
+    resolution: {integrity: sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: ^1.20251221.0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260114.0':
+    resolution: {integrity: sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260508.1':
+    resolution: {integrity: sha512-IT3r6VgiSwIesL4AJbxjgxvIxwWZqM7BKkhYAzOKHl4GF2M0TxeOahUIXd+CYXVZgHX8ceEg+MXbEehPelJyNg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260114.0':
+    resolution: {integrity: sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260508.1':
+    resolution: {integrity: sha512-JTVsisOJPcNKw0qovPjqyBWYahfdhUh7/9NICiG5wxaEQ45PYKdoqNq0hOAAIqvqoxsKZBvTgcPTJREPqk7avA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260114.0':
+    resolution: {integrity: sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260508.1':
+    resolution: {integrity: sha512-zO38pCc27YlsZiPYcaZnosy0/t7abXrRU3VEO1oKfUvnaCpHgphDG+VsrmHL+kntda6hrtNwg2jLeMAqqIjnjw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260114.0':
+    resolution: {integrity: sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260508.1':
+    resolution: {integrity: sha512-XhJa780Ia6MNIrtxn/ruZHS79b9pu5EKPfRNReaUqxy8erPT2fs93axMfFoS9kIkcaRRj/1TOUKcTeAMoywY7w==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260114.0':
+    resolution: {integrity: sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260508.1':
+    resolution: {integrity: sha512-QdDOK3B/Ul1s3QmIwDrFyx9230to6LsNmWcVR8w+TYjNZuRPzqQBgusp78LO7MlqCoEl9dvIcN00jkJnLtBSfw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260511.1':
+    resolution: {integrity: sha512-FA+si7cOq9i/gtCHhIc0XJL0l1F/ApF+m00752Aj7WZFJrj3ZulT2T8/+rT3BabMT0QEnqFEGIqCgrmqhgEfMg==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.0':
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.0':
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.0':
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.0':
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.0':
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.0':
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.0':
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.0':
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.0':
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.0':
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.0':
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.0':
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.0':
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.0':
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.0':
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.0':
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.0':
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.0':
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@oslojs/encoding@1.1.0':
+    resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/nlcst@2.0.3':
+    resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  array-iterate@2.0.1:
+    resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
+
+  astro@5.18.1:
+    resolution: {integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
+    hasBin: true
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  base-64@1.0.0:
+    resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boxen@8.0.1:
+    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
+    engines: {node: '>=18'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  common-ancestor-path@1.0.1:
+    resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@2.2.1:
+    resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  csso@5.0.5:
+    resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  deterministic-object-hash@2.0.2:
+    resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
+    engines: {node: '>=18'}
+
+  devalue@5.8.0:
+    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dset@3.1.4:
+    resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
+    engines: {node: '>=4'}
+
+  electron-to-chromium@1.5.355:
+    resolution: {integrity: sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  flattie@1.1.1:
+    resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
+    engines: {node: '>=8'}
+
+  fontace@0.4.1:
+    resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
+
+  fontkitten@1.0.3:
+    resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
+    engines: {node: '>=20'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-definitions@6.0.0:
+    resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.0.28:
+    resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  miniflare@4.20260114.0:
+    resolution: {integrity: sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  miniflare@4.20260508.0:
+    resolution: {integrity: sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  neotraverse@0.6.18:
+    resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
+    engines: {node: '>= 10'}
+
+  nlcst-to-string@4.0.0:
+    resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-mock-http@1.0.4:
+    resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
+
+  p-queue@8.1.1:
+    resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
+    engines: {node: '>=18'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse-latin@7.0.0:
+    resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  piccolore@0.1.3:
+    resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@4.0.2:
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  rehype@13.0.2:
+    resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-smartypants@3.0.2:
+    resolution: {integrity: sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==}
+    engines: {node: '>=16.0.0'}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  retext-latin@4.0.0:
+    resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
+
+  retext-smartypants@6.2.0:
+    resolution: {integrity: sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==}
+
+  retext-stringify@4.0.0:
+    resolution: {integrity: sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==}
+
+  retext@9.0.0:
+    resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  svgo@4.0.1:
+    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  ultrahtml@1.6.0:
+    resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.14.0:
+    resolution: {integrity: sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unifont@0.7.4:
+    resolution: {integrity: sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-modify-children@4.0.0:
+    resolution: {integrity: sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-children@3.0.0:
+    resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  which-pm-runs@1.1.0:
+    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
+    engines: {node: '>=4'}
+
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
+  workerd@1.20260114.0:
+    resolution: {integrity: sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  workerd@1.20260508.1:
+    resolution: {integrity: sha512-VlnjyH3AjVddpSK7J54nsCVgf8i2733pl8GjKttfNi7vN/hEjjAk20d2b1nDToOLKvRQpTewRnVkqaaeGHCaAw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.59.2:
+    resolution: {integrity: sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260114.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.90.1:
+    resolution: {integrity: sha512-u2KrieKSMfRM0toTst/CfDtcRraeoVjmcExcMWgILM/ytq3qcDhuOAULoZSyPHzma43lfLJy1BC544drFyqe1A==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260508.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  yocto-spinner@0.2.3:
+    resolution: {integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==}
+    engines: {node: '>=18.19'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod-to-ts@1.2.0:
+    resolution: {integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==}
+    peerDependencies:
+      typescript: ^4.9.4 || ^5.0.2
+      zod: ^3
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@astrojs/cloudflare@12.6.13(@types/node@22.19.19)(astro@5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(yaml@2.9.0)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.7.6
+      '@astrojs/underscore-redirects': 1.0.0
+      '@cloudflare/workers-types': 4.20260511.1
+      astro: 5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0)
+      tinyglobby: 0.2.16
+      vite: 6.4.2(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
+      wrangler: 4.59.2(@cloudflare/workers-types@4.20260511.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - utf-8-validate
+      - yaml
+
+  '@astrojs/compiler@2.13.1': {}
+
+  '@astrojs/internal-helpers@0.7.6': {}
+
+  '@astrojs/markdown-remark@6.3.11':
+    dependencies:
+      '@astrojs/internal-helpers': 0.7.6
+      '@astrojs/prism': 3.3.0
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      import-meta-resolve: 4.2.0
+      js-yaml: 4.1.1
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      shiki: 3.23.0
+      smol-toml: 1.6.1
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@astrojs/prism@3.3.0':
+    dependencies:
+      prismjs: 1.30.0
+
+  '@astrojs/tailwind@6.0.2(astro@5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(yaml@2.9.0))':
+    dependencies:
+      astro: 5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0)
+      autoprefixer: 10.5.0(postcss@8.5.14)
+      postcss: 8.5.14
+      postcss-load-config: 4.0.2(postcss@8.5.14)
+      tailwindcss: 3.4.19(yaml@2.9.0)
+    transitivePeerDependencies:
+      - ts-node
+
+  '@astrojs/telemetry@3.3.0':
+    dependencies:
+      ci-info: 4.4.0
+      debug: 4.4.3
+      dlv: 1.1.3
+      dset: 3.1.4
+      is-docker: 3.0.0
+      is-wsl: 3.1.1
+      which-pm-runs: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@astrojs/underscore-redirects@1.0.0': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@capsizecss/unpack@4.0.0':
+    dependencies:
+      fontkitten: 1.0.3
+
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.10.0(unenv@2.0.0-rc.24)(workerd@1.20260114.0)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260114.0
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260508.1
+
+  '@cloudflare/workerd-darwin-64@1.20260114.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260508.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260114.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260508.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260114.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260508.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260114.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260508.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260114.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260508.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260511.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.0':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@oslojs/encoding@1.1.0': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.3)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.3
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
+
+  '@types/nlcst@2.0.3':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.1': {}
+
+  acorn@8.16.0: {}
+
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
+  argparse@2.0.1: {}
+
+  aria-query@5.3.2: {}
+
+  array-iterate@2.0.1: {}
+
+  astro@5.18.1(@types/node@22.19.19)(jiti@1.21.7)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0):
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      '@astrojs/internal-helpers': 0.7.6
+      '@astrojs/markdown-remark': 6.3.11
+      '@astrojs/telemetry': 3.3.0
+      '@capsizecss/unpack': 4.0.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      acorn: 8.16.0
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      boxen: 8.0.1
+      ci-info: 4.4.0
+      clsx: 2.1.1
+      common-ancestor-path: 1.0.1
+      cookie: 1.1.1
+      cssesc: 3.0.0
+      debug: 4.4.3
+      deterministic-object-hash: 2.0.2
+      devalue: 5.8.0
+      diff: 8.0.4
+      dlv: 1.1.3
+      dset: 3.1.4
+      es-module-lexer: 1.7.0
+      esbuild: 0.27.7
+      estree-walker: 3.0.3
+      flattie: 1.1.1
+      fontace: 0.4.1
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      import-meta-resolve: 4.2.0
+      js-yaml: 4.1.1
+      magic-string: 0.30.21
+      magicast: 0.5.3
+      mrmime: 2.0.1
+      neotraverse: 0.6.18
+      p-limit: 6.2.0
+      p-queue: 8.1.1
+      package-manager-detector: 1.6.0
+      piccolore: 0.1.3
+      picomatch: 4.0.4
+      prompts: 2.4.2
+      rehype: 13.0.2
+      semver: 7.8.0
+      shiki: 3.23.0
+      smol-toml: 1.6.1
+      svgo: 4.0.1
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tsconfck: 3.1.6(typescript@5.9.3)
+      ultrahtml: 1.6.0
+      unifont: 0.7.4
+      unist-util-visit: 5.1.0
+      unstorage: 1.17.5
+      vfile: 6.0.3
+      vite: 6.4.2(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 21.1.1
+      yocto-spinner: 0.2.3
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+    optionalDependencies:
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - yaml
+
+  autoprefixer@10.5.0(postcss@8.5.14):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001792
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.14
+      postcss-value-parser: 4.2.0
+
+  axobject-query@4.1.0: {}
+
+  bail@2.0.2: {}
+
+  base-64@1.0.0: {}
+
+  baseline-browser-mapping@2.10.29: {}
+
+  binary-extensions@2.3.0: {}
+
+  blake3-wasm@2.1.5: {}
+
+  boolbase@1.0.0: {}
+
+  boxen@8.0.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 8.0.0
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.355
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  camelcase-css@2.0.1: {}
+
+  camelcase@8.0.0: {}
+
+  caniuse-lite@1.0.30001792: {}
+
+  ccount@2.0.1: {}
+
+  chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  ci-info@4.4.0: {}
+
+  cli-boxes@3.0.0: {}
+
+  clsx@2.1.1: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  commander@11.1.0: {}
+
+  commander@4.1.1: {}
+
+  common-ancestor-path@1.0.1: {}
+
+  cookie-es@1.2.3: {}
+
+  cookie@1.1.1: {}
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@2.2.1:
+    dependencies:
+      mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
+
+  cssesc@3.0.0: {}
+
+  csso@5.0.5:
+    dependencies:
+      css-tree: 2.2.1
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  defu@6.1.7: {}
+
+  dequal@2.0.3: {}
+
+  destr@2.0.5: {}
+
+  detect-libc@2.1.2: {}
+
+  deterministic-object-hash@2.0.2:
+    dependencies:
+      base-64: 1.0.0
+
+  devalue@5.8.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  didyoumean@1.2.2: {}
+
+  diff@8.0.4: {}
+
+  dlv@1.1.3: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dset@3.1.4: {}
+
+  electron-to-chromium@1.5.355: {}
+
+  emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  error-stack-parser-es@1.0.5: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@5.0.0: {}
+
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eventemitter3@5.0.4: {}
+
+  extend@3.0.2: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  flattie@1.1.1: {}
+
+  fontace@0.4.1:
+    dependencies:
+      fontkitten: 1.0.3
+
+  fontkitten@1.0.3:
+    dependencies:
+      tiny-inflate: 1.0.3
+
+  fraction.js@5.3.4: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  github-slugger@2.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.1
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+
+  html-escaper@3.0.3: {}
+
+  html-void-elements@3.0.0: {}
+
+  http-cache-semantics@4.2.0: {}
+
+  import-meta-resolve@4.2.0: {}
+
+  iron-webcrypto@1.2.1: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
+  is-docker@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  jiti@1.21.7: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  longest-streak@3.1.0: {}
+
+  lru-cache@11.3.6: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-definitions@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  mdn-data@2.0.28: {}
+
+  mdn-data@2.27.1: {}
+
+  merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  miniflare@4.20260114.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.14.0
+      workerd: 1.20260114.0
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  miniflare@4.20260508.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260508.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  mrmime@2.0.1: {}
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
+  neotraverse@0.6.18: {}
+
+  nlcst-to-string@4.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+
+  node-fetch-native@1.6.7: {}
+
+  node-mock-http@1.0.4: {}
+
+  node-releases@2.0.44: {}
+
+  normalize-path@3.0.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
+
+  ohash@2.0.11: {}
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  p-queue@8.1.1:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 6.1.4
+
+  p-timeout@6.1.4: {}
+
+  package-manager-detector@1.6.0: {}
+
+  parse-latin@7.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      '@types/unist': 3.0.3
+      nlcst-to-string: 4.0.0
+      unist-util-modify-children: 4.0.0
+      unist-util-visit-children: 3.0.0
+      vfile: 6.0.3
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-parse@1.0.7: {}
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
+
+  piccolore@0.1.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pify@2.3.0: {}
+
+  pirates@4.0.7: {}
+
+  postcss-import@15.1.0(postcss@8.5.14):
+    dependencies:
+      postcss: 8.5.14
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.14):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.14
+
+  postcss-load-config@4.0.2(postcss@8.5.14):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.9.0
+    optionalDependencies:
+      postcss: 8.5.14
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.14
+      yaml: 2.9.0
+
+  postcss-nested@6.2.0(postcss@8.5.14):
+    dependencies:
+      postcss: 8.5.14
+      postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prismjs@1.30.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
+  property-information@7.1.0: {}
+
+  queue-microtask@1.2.3: {}
+
+  radix3@1.1.2: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  readdirp@5.0.0: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
+  rehype@13.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      rehype-parse: 9.0.1
+      rehype-stringify: 10.0.1
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-smartypants@3.0.2:
+    dependencies:
+      retext: 9.0.0
+      retext-smartypants: 6.2.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  retext-latin@4.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      parse-latin: 7.0.0
+      unified: 11.0.5
+
+  retext-smartypants@6.2.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      nlcst-to-string: 4.0.0
+      unist-util-visit: 5.1.0
+
+  retext-stringify@4.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      nlcst-to-string: 4.0.0
+      unified: 11.0.5
+
+  retext@9.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      retext-latin: 4.0.0
+      retext-stringify: 4.0.0
+      unified: 11.0.5
+
+  reusify@1.1.0: {}
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  sax@1.6.0: {}
+
+  semver@7.8.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.0
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  sisteransi@1.0.5: {}
+
+  smol-toml@1.6.1: {}
+
+  source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
+  supports-color@10.2.2: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  svgo@4.0.1:
+    dependencies:
+      commander: 11.1.0
+      css-select: 5.2.2
+      css-tree: 3.2.1
+      css-what: 6.2.2
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.6.0
+
+  tailwindcss@3.4.19(yaml@2.9.0):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.14
+      postcss-import: 15.1.0(postcss@8.5.14)
+      postcss-js: 4.1.0(postcss@8.5.14)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.14)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tiny-inflate@1.0.3: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
+  tslib@2.8.1:
+    optional: true
+
+  type-fest@4.41.0: {}
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  ultrahtml@1.6.0: {}
+
+  uncrypto@0.1.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici@7.14.0: {}
+
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unifont@0.7.4:
+    dependencies:
+      css-tree: 3.2.1
+      ofetch: 1.5.1
+      ohash: 2.0.11
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-modify-children@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      array-iterate: 2.0.1
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-children@3.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unstorage@1.17.5:
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.3.6
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@6.4.2(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.9.0
+
+  vitefu@1.1.3(vite@6.4.2(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
+
+  web-namespaces@2.0.1: {}
+
+  which-pm-runs@1.1.0: {}
+
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
+
+  workerd@1.20260114.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260114.0
+      '@cloudflare/workerd-darwin-arm64': 1.20260114.0
+      '@cloudflare/workerd-linux-64': 1.20260114.0
+      '@cloudflare/workerd-linux-arm64': 1.20260114.0
+      '@cloudflare/workerd-windows-64': 1.20260114.0
+
+  workerd@1.20260508.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260508.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260508.1
+      '@cloudflare/workerd-linux-64': 1.20260508.1
+      '@cloudflare/workerd-linux-arm64': 1.20260508.1
+      '@cloudflare/workerd-windows-64': 1.20260508.1
+
+  wrangler@4.59.2(@cloudflare/workers-types@4.20260511.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.10.0(unenv@2.0.0-rc.24)(workerd@1.20260114.0)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.0
+      miniflare: 4.20260114.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260114.0
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260511.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.90.1(@cloudflare/workers-types@4.20260511.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260508.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260508.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260511.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  ws@8.18.0: {}
+
+  xxhash-wasm@1.1.0: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yocto-queue@1.2.2: {}
+
+  yocto-spinner@0.2.3:
+    dependencies:
+      yoctocolors: 2.1.2
+
+  yoctocolors@2.1.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      typescript: 5.9.3
+      zod: 3.25.76
+
+  zod@3.25.76: {}
+
+  zwitch@2.0.4: {}

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <text x="50%" y="50%" font-size="52" text-anchor="middle" dominant-baseline="central">📢</text>
+</svg>

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  title?: string;
+}
+const { title = 'ぱぶびゅ！ダッシュボード' } = Astro.props;
+---
+<!doctype html>
+<html lang="ja" class="bg-slate-950 text-slate-100">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>{title}</title>
+  </head>
+  <body class="min-h-screen antialiased">
+    <slot />
+  </body>
+</html>

--- a/web/src/lib/houses.ts
+++ b/web/src/lib/houses.ts
@@ -1,0 +1,35 @@
+export interface HouseDef {
+  id: string;
+  name: string;
+  emoji: string;
+  themeBg: string;
+  themeRing: string;
+  themeAccent: string;
+  themeBar: string;
+}
+
+export const HOUSES: HouseDef[] = [
+  { id: 'raptor', name: 'ラプター', emoji: '🦖', themeBg: 'bg-raptor-dark/40', themeRing: 'ring-raptor/40', themeAccent: 'text-raptor', themeBar: 'bg-raptor' },
+  { id: 'krug',   name: 'クルーグ', emoji: '🪨', themeBg: 'bg-krug-dark/40',   themeRing: 'ring-krug/40',   themeAccent: 'text-krug',   themeBar: 'bg-krug' },
+  { id: 'wolf',   name: 'ウルフ',   emoji: '🐺', themeBg: 'bg-wolf-dark/40',   themeRing: 'ring-wolf/40',   themeAccent: 'text-wolf',   themeBar: 'bg-wolf' },
+  { id: 'gromp',  name: 'グロンプ', emoji: '🐸', themeBg: 'bg-gromp-dark/40',  themeRing: 'ring-gromp/40',  themeAccent: 'text-gromp',  themeBar: 'bg-gromp' },
+];
+
+export const HOUSE_LEVEL_COEF = 300;
+export const HOUSE_LEVEL_EXP = 2.0;
+export const USER_LEVEL_COEF = 20;
+export const USER_LEVEL_EXP = 2.0;
+
+export function levelFromXp(xp: number, coef: number, exp: number): number {
+  if (xp <= 0) return 1;
+  return Math.max(1, Math.floor((xp / coef) ** (1.0 / exp)));
+}
+
+export function requiredXpForLevel(level: number, coef: number, exp: number): number {
+  if (level <= 1) return 0;
+  return Math.floor(coef * level ** exp);
+}
+
+export function houseById(id: string): HouseDef | undefined {
+  return HOUSES.find((h) => h.id === id);
+}

--- a/web/src/pages/api/ingest.ts
+++ b/web/src/pages/api/ingest.ts
@@ -37,12 +37,20 @@ interface MonthlyRow {
   text_messages: number;
 }
 
+interface HouseLeaderRow {
+  house_id: string;
+  discord_id: string;
+  set_at: string;
+  set_by?: string | null;
+}
+
 interface IngestPayload {
   bot_version?: string;
   users: UserRow[];
   sorting_hat: SortingHatRow[];
   contribution_totals: TotalsRow[];
   contribution_monthly: MonthlyRow[];
+  house_leaders?: HouseLeaderRow[];
 }
 
 export const POST: APIRoute = async ({ request, locals }) => {
@@ -68,7 +76,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const { users = [], sorting_hat = [], contribution_totals = [], contribution_monthly = [] } = payload;
+  const { users = [], sorting_hat = [], contribution_totals = [], contribution_monthly = [], house_leaders = [] } = payload;
 
   const statements: D1PreparedStatement[] = [];
 
@@ -141,6 +149,19 @@ export const POST: APIRoute = async ({ request, locals }) => {
     );
   }
 
+  for (const l of house_leaders) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO house_leaders (house_id, discord_id, set_at, set_by)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(house_id) DO UPDATE SET
+           discord_id = excluded.discord_id,
+           set_at     = excluded.set_at,
+           set_by     = excluded.set_by`,
+      ).bind(l.house_id, l.discord_id, l.set_at, l.set_by ?? null),
+    );
+  }
+
   statements.push(
     env.DB.prepare(
       `INSERT INTO ingest_log (ingested_at, users_count, sorting_count, totals_count, monthly_count, bot_version)
@@ -165,6 +186,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         sorting_hat: sorting_hat.length,
         contribution_totals: contribution_totals.length,
         contribution_monthly: contribution_monthly.length,
+        house_leaders: house_leaders.length,
       },
     }),
     { status: 200, headers: { 'content-type': 'application/json' } },

--- a/web/src/pages/api/ingest.ts
+++ b/web/src/pages/api/ingest.ts
@@ -44,6 +44,14 @@ interface HouseLeaderRow {
   set_by?: string | null;
 }
 
+interface DailySnapshotRow {
+  snapshot_date: string;
+  discord_id: string;
+  total_xp: number;
+  vc_seconds: number;
+  text_messages: number;
+}
+
 interface IngestPayload {
   bot_version?: string;
   users: UserRow[];
@@ -51,6 +59,7 @@ interface IngestPayload {
   contribution_totals: TotalsRow[];
   contribution_monthly: MonthlyRow[];
   house_leaders?: HouseLeaderRow[];
+  daily_snapshots?: DailySnapshotRow[];
 }
 
 export const POST: APIRoute = async ({ request, locals }) => {
@@ -76,7 +85,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const { users = [], sorting_hat = [], contribution_totals = [], contribution_monthly = [], house_leaders = [] } = payload;
+  const { users = [], sorting_hat = [], contribution_totals = [], contribution_monthly = [], house_leaders = [], daily_snapshots = [] } = payload;
 
   const statements: D1PreparedStatement[] = [];
 
@@ -162,6 +171,19 @@ export const POST: APIRoute = async ({ request, locals }) => {
     );
   }
 
+  for (const d of daily_snapshots) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO daily_snapshots (snapshot_date, discord_id, total_xp, vc_seconds, text_messages)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(snapshot_date, discord_id) DO UPDATE SET
+           total_xp      = excluded.total_xp,
+           vc_seconds    = excluded.vc_seconds,
+           text_messages = excluded.text_messages`,
+      ).bind(d.snapshot_date, d.discord_id, d.total_xp, d.vc_seconds, d.text_messages),
+    );
+  }
+
   statements.push(
     env.DB.prepare(
       `INSERT INTO ingest_log (ingested_at, users_count, sorting_count, totals_count, monthly_count, bot_version)
@@ -187,6 +209,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         contribution_totals: contribution_totals.length,
         contribution_monthly: contribution_monthly.length,
         house_leaders: house_leaders.length,
+        daily_snapshots: daily_snapshots.length,
       },
     }),
     { status: 200, headers: { 'content-type': 'application/json' } },

--- a/web/src/pages/api/ingest.ts
+++ b/web/src/pages/api/ingest.ts
@@ -1,0 +1,172 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+interface UserRow {
+  discord_id: string;
+  display_name: string;
+  avatar_url?: string | null;
+  riot_game_name?: string | null;
+  riot_tag_line?: string | null;
+  tier?: string | null;
+  rank?: string | null;
+  league_points?: number | null;
+}
+
+interface SortingHatRow {
+  discord_id: string;
+  house_id: string;
+  rate_bracket: string;
+  tier: string;
+  sorted_at: string;
+}
+
+interface TotalsRow {
+  discord_id: string;
+  total_xp: number;
+  vc_seconds: number;
+  text_messages: number;
+  updated_at: string;
+}
+
+interface MonthlyRow {
+  year_month: string;
+  discord_id: string;
+  points: number;
+  vc_seconds: number;
+  text_messages: number;
+}
+
+interface IngestPayload {
+  bot_version?: string;
+  users: UserRow[];
+  sorting_hat: SortingHatRow[];
+  contribution_totals: TotalsRow[];
+  contribution_monthly: MonthlyRow[];
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const env = (locals as { runtime: { env: { DB: D1Database; INGEST_TOKEN: string } } }).runtime.env;
+
+  // 認証: Bearer トークン
+  const auth = request.headers.get('authorization') ?? '';
+  const expected = `Bearer ${env.INGEST_TOKEN}`;
+  if (!env.INGEST_TOKEN || auth !== expected) {
+    return new Response(JSON.stringify({ error: 'unauthorized' }), {
+      status: 401,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  let payload: IngestPayload;
+  try {
+    payload = (await request.json()) as IngestPayload;
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid_json' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  const { users = [], sorting_hat = [], contribution_totals = [], contribution_monthly = [] } = payload;
+
+  const statements: D1PreparedStatement[] = [];
+
+  for (const u of users) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO users (discord_id, display_name, avatar_url, riot_game_name, riot_tag_line, tier, rank, league_points, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(discord_id) DO UPDATE SET
+           display_name   = excluded.display_name,
+           avatar_url     = excluded.avatar_url,
+           riot_game_name = excluded.riot_game_name,
+           riot_tag_line  = excluded.riot_tag_line,
+           tier           = excluded.tier,
+           rank           = excluded.rank,
+           league_points  = excluded.league_points,
+           updated_at     = excluded.updated_at`,
+      ).bind(
+        u.discord_id,
+        u.display_name,
+        u.avatar_url ?? null,
+        u.riot_game_name ?? null,
+        u.riot_tag_line ?? null,
+        u.tier ?? null,
+        u.rank ?? null,
+        u.league_points ?? null,
+        new Date().toISOString(),
+      ),
+    );
+  }
+
+  for (const s of sorting_hat) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO sorting_hat (discord_id, house_id, rate_bracket, tier, sorted_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(discord_id) DO UPDATE SET
+           house_id     = excluded.house_id,
+           rate_bracket = excluded.rate_bracket,
+           tier         = excluded.tier,
+           sorted_at    = excluded.sorted_at`,
+      ).bind(s.discord_id, s.house_id, s.rate_bracket, s.tier, s.sorted_at),
+    );
+  }
+
+  for (const t of contribution_totals) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO contribution_totals (discord_id, total_xp, vc_seconds, text_messages, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(discord_id) DO UPDATE SET
+           total_xp      = excluded.total_xp,
+           vc_seconds    = excluded.vc_seconds,
+           text_messages = excluded.text_messages,
+           updated_at    = excluded.updated_at`,
+      ).bind(t.discord_id, t.total_xp, t.vc_seconds, t.text_messages, t.updated_at),
+    );
+  }
+
+  for (const m of contribution_monthly) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO contribution_monthly (year_month, discord_id, points, vc_seconds, text_messages)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(year_month, discord_id) DO UPDATE SET
+           points        = excluded.points,
+           vc_seconds    = excluded.vc_seconds,
+           text_messages = excluded.text_messages`,
+      ).bind(m.year_month, m.discord_id, m.points, m.vc_seconds, m.text_messages),
+    );
+  }
+
+  statements.push(
+    env.DB.prepare(
+      `INSERT INTO ingest_log (ingested_at, users_count, sorting_count, totals_count, monthly_count, bot_version)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      new Date().toISOString(),
+      users.length,
+      sorting_hat.length,
+      contribution_totals.length,
+      contribution_monthly.length,
+      payload.bot_version ?? null,
+    ),
+  );
+
+  await env.DB.batch(statements);
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      counts: {
+        users: users.length,
+        sorting_hat: sorting_hat.length,
+        contribution_totals: contribution_totals.length,
+        contribution_monthly: contribution_monthly.length,
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+};

--- a/web/src/pages/houses/[house_id].astro
+++ b/web/src/pages/houses/[house_id].astro
@@ -1,0 +1,218 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import {
+  HOUSES,
+  houseById,
+  levelFromXp,
+  requiredXpForLevel,
+  HOUSE_LEVEL_COEF,
+  HOUSE_LEVEL_EXP,
+  USER_LEVEL_COEF,
+  USER_LEVEL_EXP,
+} from '../../lib/houses.ts';
+
+export const prerender = false;
+
+const houseId = Astro.params.house_id;
+const houseDef = houseById(houseId ?? '');
+if (!houseDef) {
+  return new Response('House not found', { status: 404 });
+}
+
+const env = (Astro.locals as { runtime?: { env?: { DB?: D1Database } } }).runtime?.env;
+const currentYm = new Date().toLocaleString('sv-SE', { timeZone: 'Asia/Tokyo' }).slice(0, 7);
+
+interface MemberRow {
+  discord_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  total_xp: number;
+  vc_seconds: number;
+  text_messages: number;
+  month_pt: number;
+}
+interface HouseStats {
+  member_count: number;
+  total_xp: number;
+  monthly_points: number;
+}
+
+let stats: HouseStats = { member_count: 0, total_xp: 0, monthly_points: 0 };
+let members: MemberRow[] = [];
+let leaderName: string | null = null;
+
+if (env?.DB) {
+  const statsRow = await env.DB.prepare(
+    `SELECT COUNT(DISTINCT sh.discord_id) AS member_count,
+            COALESCE(SUM(ct.total_xp), 0)  AS total_xp,
+            COALESCE(SUM(cm.points), 0)    AS monthly_points
+     FROM sorting_hat sh
+     LEFT JOIN contribution_totals ct ON sh.discord_id = ct.discord_id
+     LEFT JOIN contribution_monthly cm ON sh.discord_id = cm.discord_id AND cm.year_month = ?
+     WHERE sh.house_id = ?`,
+  ).bind(currentYm, houseId).first<HouseStats>();
+  if (statsRow) stats = statsRow;
+
+  const membersResult = await env.DB.prepare(
+    `SELECT u.discord_id, u.display_name, u.avatar_url,
+            COALESCE(ct.total_xp, 0)      AS total_xp,
+            COALESCE(ct.vc_seconds, 0)    AS vc_seconds,
+            COALESCE(ct.text_messages, 0) AS text_messages,
+            COALESCE(cm.points, 0)        AS month_pt
+     FROM sorting_hat sh
+     JOIN users u ON sh.discord_id = u.discord_id
+     LEFT JOIN contribution_totals  ct ON sh.discord_id = ct.discord_id
+     LEFT JOIN contribution_monthly cm ON sh.discord_id = cm.discord_id AND cm.year_month = ?
+     WHERE sh.house_id = ?
+     ORDER BY total_xp DESC`,
+  ).bind(currentYm, houseId).all<MemberRow>();
+  members = membersResult.results ?? [];
+
+  const leaderRow = await env.DB.prepare(
+    `SELECT u.display_name
+     FROM house_leaders hl
+     JOIN users u ON hl.discord_id = u.discord_id
+     WHERE hl.house_id = ?`,
+  ).bind(houseId).first<{ display_name: string }>();
+  leaderName = leaderRow?.display_name ?? null;
+}
+
+const houseLv = levelFromXp(stats.total_xp, HOUSE_LEVEL_COEF, HOUSE_LEVEL_EXP);
+const houseCurXp = requiredXpForLevel(houseLv, HOUSE_LEVEL_COEF, HOUSE_LEVEL_EXP);
+const houseNextXp = requiredXpForLevel(houseLv + 1, HOUSE_LEVEL_COEF, HOUSE_LEVEL_EXP);
+const houseProgress = houseNextXp > houseCurXp
+  ? Math.min(100, Math.max(0, ((stats.total_xp - houseCurXp) / (houseNextXp - houseCurXp)) * 100))
+  : 0;
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+function vcHM(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+function userLevelInfo(xp: number) {
+  const level = levelFromXp(xp, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const curXp = requiredXpForLevel(level, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const nextXp = requiredXpForLevel(level + 1, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const inLv = xp - curXp;
+  const span = Math.max(1, nextXp - curXp);
+  const progress = Math.min(100, Math.max(0, (inLv / span) * 100));
+  return { level, inLv, span, progress };
+}
+---
+<Layout title={`${houseDef.name} | ぱぶびゅ！ダッシュボード`}>
+  <main class="mx-auto max-w-5xl px-4 py-10 sm:px-6 sm:py-14">
+    <nav class="mb-6 text-sm">
+      <a href="/" class="text-slate-400 hover:text-slate-200">← 寮対抗ボードへ戻る</a>
+    </nav>
+
+    <header class={`rounded-2xl ${houseDef.themeBg} p-6 ring-1 ${houseDef.themeRing} sm:p-8`}>
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div class="text-6xl leading-none">{houseDef.emoji}</div>
+          <h1 class={`mt-3 text-3xl font-black tracking-tight sm:text-4xl ${houseDef.themeAccent}`}>{houseDef.name}</h1>
+          <p class="mt-1 text-sm text-slate-300">
+            寮長: {leaderName ? <span class="font-semibold text-slate-100">{leaderName}</span> : <span class="text-slate-500">未任命</span>}
+          </p>
+        </div>
+        <div class="text-right">
+          <div class="text-xs text-slate-300">寮Lv</div>
+          <div class="text-5xl font-black tabular-nums">{houseLv}</div>
+        </div>
+      </div>
+
+      <div class="mt-5">
+        <div class="flex items-baseline justify-between text-xs text-slate-200">
+          <span>{fmt(stats.total_xp - houseCurXp)} / {fmt(houseNextXp - houseCurXp)} XP</span>
+          <span>次Lvまで</span>
+        </div>
+        <div class="mt-1 h-2.5 overflow-hidden rounded-full bg-slate-900/70">
+          <div class={`h-full ${houseDef.themeBar}`} style={`width: ${houseProgress}%`}></div>
+        </div>
+      </div>
+    </header>
+
+    <section class="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">累積XP</div>
+        <div class="mt-1 text-2xl font-bold tabular-nums">{fmt(stats.total_xp)}</div>
+      </div>
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">今月pt</div>
+        <div class="mt-1 text-2xl font-bold tabular-nums">{fmt(stats.monthly_points)}</div>
+      </div>
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">メンバー</div>
+        <div class="mt-1 text-2xl font-bold tabular-nums">{stats.member_count}<span class="ml-0.5 text-base font-normal">人</span></div>
+      </div>
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">寮Lv</div>
+        <div class={`mt-1 text-2xl font-bold tabular-nums ${houseDef.themeAccent}`}>Lv {houseLv}</div>
+      </div>
+    </section>
+
+    <section class="mt-8 rounded-2xl bg-slate-900/60 p-5 ring-1 ring-slate-800 sm:p-6">
+      <div class="flex items-baseline justify-between">
+        <h2 class="text-lg font-bold">メンバー（累積XP順）</h2>
+        <p class="text-xs text-slate-500">{members.length} 名</p>
+      </div>
+
+      {members.length === 0 ? (
+        <p class="mt-6 text-sm text-slate-500">まだメンバーがいません。</p>
+      ) : (
+        <ol class="mt-4 divide-y divide-slate-800">
+          {members.map((m, i) => {
+            const lv = userLevelInfo(m.total_xp);
+            return (
+              <li class="flex items-center gap-3 py-3 text-sm">
+                <span class="w-8 text-right font-mono text-slate-500 tabular-nums">#{i + 1}</span>
+                <img
+                  src={m.avatar_url ?? '/favicon.svg'}
+                  alt=""
+                  loading="lazy"
+                  class="h-8 w-8 shrink-0 rounded-full bg-slate-800 object-cover"
+                />
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <a href={`/u/${encodeURIComponent(m.display_name)}`} class="truncate font-medium hover:underline">{m.display_name}</a>
+                    <span class={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-slate-100 ${houseDef.themeBar}`}>Lv {lv.level}</span>
+                  </div>
+                  <div class="mt-1 flex items-center gap-2">
+                    <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-800">
+                      <div class={`h-full ${houseDef.themeBar}`} style={`width: ${lv.progress}%`}></div>
+                    </div>
+                    <span class="shrink-0 font-mono text-[10px] text-slate-500 tabular-nums">
+                      {fmt(lv.inLv)}/{fmt(lv.span)} XP
+                    </span>
+                  </div>
+                </div>
+                <div class="shrink-0 text-right">
+                  <div class="font-mono text-slate-200 tabular-nums">{fmt(m.month_pt)} pt</div>
+                  <div class="text-[10px] text-slate-500 tabular-nums">VC {vcHM(m.vc_seconds)} ・ {fmt(m.text_messages)}件</div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+
+    <footer class="mt-10 flex flex-wrap items-center justify-between gap-2 border-t border-slate-800 pt-6 text-xs text-slate-500">
+      <span>4寮:
+        {HOUSES.map((h, i) => (
+          <>
+            {i > 0 && ' / '}
+            {h.id === houseId ? (
+              <span class={`font-semibold ${h.themeAccent}`}>{h.emoji} {h.name}</span>
+            ) : (
+              <a href={`/houses/${h.id}`} class="hover:text-slate-300">{h.emoji} {h.name}</a>
+            )}
+          </>
+        ))}
+      </span>
+      <a href="/" class="hover:text-slate-300">トップへ →</a>
+    </footer>
+  </main>
+</Layout>

--- a/web/src/pages/houses/[house_id].astro
+++ b/web/src/pages/houses/[house_id].astro
@@ -125,8 +125,8 @@ function userLevelInfo(xp: number) {
 
       <div class="mt-5">
         <div class="flex items-baseline justify-between text-xs text-slate-200">
+          <span>次Lv {houseLv + 1} まで</span>
           <span>{fmt(stats.total_xp - houseCurXp)} / {fmt(houseNextXp - houseCurXp)} XP</span>
-          <span>次Lvまで</span>
         </div>
         <div class="mt-1 h-2.5 overflow-hidden rounded-full bg-slate-900/70">
           <div class={`h-full ${houseDef.themeBar}`} style={`width: ${houseProgress}%`}></div>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -136,8 +136,9 @@ function userLevelInfo(xp: number) {
         const progress = nextXp > curXp ? Math.min(100, Math.max(0, ((s.total_xp - curXp) / (nextXp - curXp)) * 100)) : 0;
         const tops = topByHouse[h.id] ?? [];
         return (
-          <article class={`rounded-2xl ${h.themeBg} p-5 ring-1 ${h.themeRing}`}>
-            <div class="flex items-start justify-between">
+          <article class={`group relative rounded-2xl ${h.themeBg} p-5 ring-1 ${h.themeRing} transition hover:ring-2`}>
+            <a href={`/houses/${h.id}`} class="absolute inset-0 z-0 rounded-2xl" aria-label={`${h.name} の詳細`}></a>
+            <div class="relative z-10 flex items-start justify-between">
               <div>
                 <div class="text-4xl leading-none">{h.emoji}</div>
                 <h2 class={`mt-2 text-lg font-bold ${h.themeAccent}`}>{h.name}</h2>
@@ -181,10 +182,10 @@ function userLevelInfo(xp: number) {
                   {tops.map((m, i) => {
                     const lv = userLevelInfo(m.total_xp);
                     return (
-                      <li class="flex items-baseline justify-between gap-3">
+                      <li class="relative flex items-baseline justify-between gap-3">
                         <span class="truncate">
                           <span class="mr-1 text-slate-500 tabular-nums">{i + 1}.</span>
-                          {m.display_name}
+                          <a href={`/u/${encodeURIComponent(m.display_name)}`} class="relative z-10 hover:underline">{m.display_name}</a>
                           <span class="ml-1.5 rounded bg-slate-800/80 px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-slate-200">Lv {lv.level}</span>
                         </span>
                         <span class="font-mono text-xs text-slate-300 tabular-nums">{fmt(m.points)}</span>
@@ -220,7 +221,7 @@ function userLevelInfo(xp: number) {
                 </span>
                 <div class="min-w-0 flex-1">
                   <div class="flex items-center gap-2">
-                    <span class="truncate font-medium">{m.display_name}</span>
+                    <a href={`/u/${encodeURIComponent(m.display_name)}`} class="truncate font-medium hover:underline">{m.display_name}</a>
                     <span class={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-slate-100 ${h?.themeBar ?? 'bg-slate-700'}`}>Lv {lv.level}</span>
                   </div>
                   <div class="mt-1 flex items-center gap-2">
@@ -238,8 +239,16 @@ function userLevelInfo(xp: number) {
       </ol>
     </section>
 
-    <footer class="mt-12 border-t border-slate-800 pt-6 text-xs text-slate-500">
-      <p>個別の寮詳細・累積ランキング・個人ページは順次追加します（Phase 3）。</p>
+    <footer class="mt-12 flex flex-wrap items-center justify-between gap-3 border-t border-slate-800 pt-6 text-xs text-slate-500">
+      <div class="flex flex-wrap gap-3">
+        <a href="/leaderboard" class="hover:text-slate-200">🏆 全体ランキング</a>
+        <a href={`/monthly/${currentYm}`} class="hover:text-slate-200">📅 月次アーカイブ</a>
+      </div>
+      <div class="flex flex-wrap gap-3 text-slate-500">
+        {HOUSES.map((h) => (
+          <a href={`/houses/${h.id}`} class="hover:text-slate-200">{h.emoji} {h.name}</a>
+        ))}
+      </div>
     </footer>
   </main>
 </Layout>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,0 +1,51 @@
+---
+import Layout from '../layouts/Layout.astro';
+
+export const prerender = false;
+
+const env = (Astro.locals as { runtime?: { env?: { DB?: D1Database } } }).runtime?.env;
+let lastIngest: { ingested_at: string; users_count: number } | null = null;
+if (env?.DB) {
+  const row = await env.DB.prepare(
+    `SELECT ingested_at, users_count FROM ingest_log ORDER BY id DESC LIMIT 1`,
+  ).first<{ ingested_at: string; users_count: number }>();
+  lastIngest = row ?? null;
+}
+---
+<Layout title="ぱぶびゅ！ダッシュボード">
+  <main class="mx-auto max-w-3xl px-6 py-16">
+    <h1 class="text-3xl font-bold tracking-tight">ぱぶびゅ！ダッシュボード</h1>
+    <p class="mt-4 text-slate-400">Phase 3 セットアップ中。同期と画面は順次追加されます。</p>
+
+    <section class="mt-12 grid grid-cols-2 gap-4 sm:grid-cols-4">
+      <div class="rounded-xl bg-raptor-dark/40 p-4 ring-1 ring-raptor/40">
+        <div class="text-3xl">🦖</div>
+        <div class="mt-2 text-sm text-slate-300">ラプター</div>
+      </div>
+      <div class="rounded-xl bg-krug-dark/40 p-4 ring-1 ring-krug/40">
+        <div class="text-3xl">🪨</div>
+        <div class="mt-2 text-sm text-slate-300">クルーグ</div>
+      </div>
+      <div class="rounded-xl bg-wolf-dark/40 p-4 ring-1 ring-wolf/40">
+        <div class="text-3xl">🐺</div>
+        <div class="mt-2 text-sm text-slate-300">ウルフ</div>
+      </div>
+      <div class="rounded-xl bg-gromp-dark/40 p-4 ring-1 ring-gromp/40">
+        <div class="text-3xl">🐸</div>
+        <div class="mt-2 text-sm text-slate-300">グロンプ</div>
+      </div>
+    </section>
+
+    <section class="mt-12 rounded-xl bg-slate-900/60 p-6 ring-1 ring-slate-800">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400">同期ステータス</h2>
+      {lastIngest ? (
+        <p class="mt-2 text-slate-200">
+          最終同期: <span class="font-mono">{lastIngest.ingested_at}</span>
+          （ユーザー {lastIngest.users_count} 件）
+        </p>
+      ) : (
+        <p class="mt-2 text-slate-400">まだ同期データが届いていません。</p>
+      )}
+    </section>
+  </main>
+</Layout>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,51 +1,245 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { HOUSES, houseById, levelFromXp, requiredXpForLevel, HOUSE_LEVEL_COEF, HOUSE_LEVEL_EXP, USER_LEVEL_COEF, USER_LEVEL_EXP } from '../lib/houses.ts';
 
 export const prerender = false;
 
 const env = (Astro.locals as { runtime?: { env?: { DB?: D1Database } } }).runtime?.env;
-let lastIngest: { ingested_at: string; users_count: number } | null = null;
+
+const currentYm = new Date().toLocaleString('sv-SE', { timeZone: 'Asia/Tokyo' }).slice(0, 7);
+
+interface HouseStats {
+  house_id: string;
+  member_count: number;
+  total_xp: number;
+  monthly_points: number;
+}
+interface TopMember {
+  discord_id: string;
+  display_name: string;
+  house_id: string;
+  points: number;
+  total_xp: number;
+}
+interface LastIngest {
+  ingested_at: string;
+  users_count: number;
+}
+
+let houseStats: HouseStats[] = [];
+let topByHouse: Record<string, TopMember[]> = {};
+let overallTop: TopMember[] = [];
+let lastIngest: LastIngest | null = null;
+let leaderByHouse: Record<string, string> = {};
+
 if (env?.DB) {
-  const row = await env.DB.prepare(
+  const statsResult = await env.DB.prepare(
+    `SELECT sh.house_id,
+            COUNT(DISTINCT sh.discord_id) AS member_count,
+            COALESCE(SUM(ct.total_xp), 0)    AS total_xp,
+            COALESCE(SUM(cm.points), 0)      AS monthly_points
+     FROM sorting_hat sh
+     LEFT JOIN contribution_totals ct ON sh.discord_id = ct.discord_id
+     LEFT JOIN contribution_monthly cm
+       ON sh.discord_id = cm.discord_id AND cm.year_month = ?
+     GROUP BY sh.house_id`,
+  ).bind(currentYm).all<HouseStats>();
+  houseStats = statsResult.results ?? [];
+
+  const overallResult = await env.DB.prepare(
+    `SELECT u.discord_id, u.display_name, sh.house_id,
+            COALESCE(cm.points, 0)   AS points,
+            COALESCE(ct.total_xp, 0) AS total_xp
+     FROM users u
+     JOIN sorting_hat sh ON u.discord_id = sh.discord_id
+     LEFT JOIN contribution_totals ct ON u.discord_id = ct.discord_id
+     LEFT JOIN contribution_monthly cm
+       ON u.discord_id = cm.discord_id AND cm.year_month = ?
+     ORDER BY points DESC
+     LIMIT 10`,
+  ).bind(currentYm).all<TopMember>();
+  overallTop = overallResult.results ?? [];
+
+  for (const h of HOUSES) {
+    const r = await env.DB.prepare(
+      `SELECT u.discord_id, u.display_name, sh.house_id,
+              COALESCE(cm.points, 0)   AS points,
+              COALESCE(ct.total_xp, 0) AS total_xp
+       FROM users u
+       JOIN sorting_hat sh ON u.discord_id = sh.discord_id
+       LEFT JOIN contribution_totals ct ON u.discord_id = ct.discord_id
+       LEFT JOIN contribution_monthly cm
+         ON u.discord_id = cm.discord_id AND cm.year_month = ?
+       WHERE sh.house_id = ?
+       ORDER BY points DESC
+       LIMIT 5`,
+    ).bind(currentYm, h.id).all<TopMember>();
+    topByHouse[h.id] = r.results ?? [];
+  }
+
+  const last = await env.DB.prepare(
     `SELECT ingested_at, users_count FROM ingest_log ORDER BY id DESC LIMIT 1`,
-  ).first<{ ingested_at: string; users_count: number }>();
-  lastIngest = row ?? null;
+  ).first<LastIngest>();
+  lastIngest = last ?? null;
+
+  const leaders = await env.DB.prepare(
+    `SELECT hl.house_id, u.display_name AS leader_name
+     FROM house_leaders hl
+     LEFT JOIN users u ON hl.discord_id = u.discord_id`,
+  ).all<{ house_id: string; leader_name: string | null }>();
+  for (const row of leaders.results ?? []) {
+    if (row.leader_name) leaderByHouse[row.house_id] = row.leader_name;
+  }
+}
+
+function statsFor(houseId: string): HouseStats {
+  return houseStats.find((s) => s.house_id === houseId) ?? {
+    house_id: houseId, member_count: 0, total_xp: 0, monthly_points: 0,
+  };
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function formatHours(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+function userLevelInfo(xp: number) {
+  const level = levelFromXp(xp, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const curXp = requiredXpForLevel(level, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const nextXp = requiredXpForLevel(level + 1, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const progress = nextXp > curXp ? Math.min(100, Math.max(0, ((xp - curXp) / (nextXp - curXp)) * 100)) : 0;
+  return { level, curXp, nextXp, progress, inLevel: xp - curXp, span: nextXp - curXp };
 }
 ---
 <Layout title="ぱぶびゅ！ダッシュボード">
-  <main class="mx-auto max-w-3xl px-6 py-16">
-    <h1 class="text-3xl font-bold tracking-tight">ぱぶびゅ！ダッシュボード</h1>
-    <p class="mt-4 text-slate-400">Phase 3 セットアップ中。同期と画面は順次追加されます。</p>
+  <main class="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-16">
+    <header class="flex flex-col gap-1">
+      <p class="text-xs uppercase tracking-[0.3em] text-slate-500">pubview / contribution dashboard</p>
+      <h1 class="text-3xl font-bold tracking-tight sm:text-4xl">寮対抗ボード</h1>
+      <p class="mt-1 text-sm text-slate-400">
+        {currentYm} の貢献度 ・ <span class="font-mono">{lastIngest ? `last sync ${new Date(lastIngest.ingested_at).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}` : 'no sync yet'}</span>
+      </p>
+    </header>
 
-    <section class="mt-12 grid grid-cols-2 gap-4 sm:grid-cols-4">
-      <div class="rounded-xl bg-raptor-dark/40 p-4 ring-1 ring-raptor/40">
-        <div class="text-3xl">🦖</div>
-        <div class="mt-2 text-sm text-slate-300">ラプター</div>
-      </div>
-      <div class="rounded-xl bg-krug-dark/40 p-4 ring-1 ring-krug/40">
-        <div class="text-3xl">🪨</div>
-        <div class="mt-2 text-sm text-slate-300">クルーグ</div>
-      </div>
-      <div class="rounded-xl bg-wolf-dark/40 p-4 ring-1 ring-wolf/40">
-        <div class="text-3xl">🐺</div>
-        <div class="mt-2 text-sm text-slate-300">ウルフ</div>
-      </div>
-      <div class="rounded-xl bg-gromp-dark/40 p-4 ring-1 ring-gromp/40">
-        <div class="text-3xl">🐸</div>
-        <div class="mt-2 text-sm text-slate-300">グロンプ</div>
-      </div>
+    <!-- 4寮カード -->
+    <section class="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {HOUSES.map((h) => {
+        const s = statsFor(h.id);
+        const level = levelFromXp(s.total_xp, HOUSE_LEVEL_COEF, HOUSE_LEVEL_EXP);
+        const curXp = requiredXpForLevel(level, HOUSE_LEVEL_COEF, HOUSE_LEVEL_EXP);
+        const nextXp = requiredXpForLevel(level + 1, HOUSE_LEVEL_COEF, HOUSE_LEVEL_EXP);
+        const progress = nextXp > curXp ? Math.min(100, Math.max(0, ((s.total_xp - curXp) / (nextXp - curXp)) * 100)) : 0;
+        const tops = topByHouse[h.id] ?? [];
+        return (
+          <article class={`rounded-2xl ${h.themeBg} p-5 ring-1 ${h.themeRing}`}>
+            <div class="flex items-start justify-between">
+              <div>
+                <div class="text-4xl leading-none">{h.emoji}</div>
+                <h2 class={`mt-2 text-lg font-bold ${h.themeAccent}`}>{h.name}</h2>
+                <p class="mt-0.5 text-xs text-slate-400">
+                  寮長: {leaderByHouse[h.id] ? <span class="text-slate-200">{leaderByHouse[h.id]}</span> : <span class="text-slate-500">未任命</span>}
+                </p>
+              </div>
+              <div class="text-right">
+                <div class="text-xs text-slate-400">寮Lv</div>
+                <div class="text-2xl font-black tabular-nums">{level}</div>
+              </div>
+            </div>
+
+            <div class="mt-3">
+              <div class="flex items-baseline justify-between text-xs text-slate-400">
+                <span>{fmt(s.total_xp - curXp)} / {fmt(nextXp - curXp)} XP</span>
+                <span>次Lvまで</span>
+              </div>
+              <div class="mt-1 h-2 overflow-hidden rounded-full bg-slate-900/70">
+                <div class={`h-full ${h.themeBar}`} style={`width: ${progress}%`}></div>
+              </div>
+            </div>
+
+            <dl class="mt-4 grid grid-cols-2 gap-2 text-sm">
+              <div>
+                <dt class="text-xs text-slate-400">今月pt</dt>
+                <dd class="font-bold tabular-nums">{fmt(s.monthly_points)}</dd>
+              </div>
+              <div>
+                <dt class="text-xs text-slate-400">メンバー</dt>
+                <dd class="font-bold tabular-nums">{s.member_count}人</dd>
+              </div>
+            </dl>
+
+            <div class="mt-4 border-t border-slate-700/40 pt-3">
+              <p class="mb-1 text-xs uppercase tracking-wider text-slate-400">今月トップ</p>
+              {tops.length === 0 ? (
+                <p class="text-xs text-slate-500">まだ記録なし</p>
+              ) : (
+                <ol class="space-y-1.5 text-sm">
+                  {tops.map((m, i) => {
+                    const lv = userLevelInfo(m.total_xp);
+                    return (
+                      <li class="flex items-baseline justify-between gap-3">
+                        <span class="truncate">
+                          <span class="mr-1 text-slate-500 tabular-nums">{i + 1}.</span>
+                          {m.display_name}
+                          <span class="ml-1.5 rounded bg-slate-800/80 px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-slate-200">Lv {lv.level}</span>
+                        </span>
+                        <span class="font-mono text-xs text-slate-300 tabular-nums">{fmt(m.points)}</span>
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
+            </div>
+          </article>
+        );
+      })}
     </section>
 
-    <section class="mt-12 rounded-xl bg-slate-900/60 p-6 ring-1 ring-slate-800">
-      <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400">同期ステータス</h2>
-      {lastIngest ? (
-        <p class="mt-2 text-slate-200">
-          最終同期: <span class="font-mono">{lastIngest.ingested_at}</span>
-          （ユーザー {lastIngest.users_count} 件）
-        </p>
-      ) : (
-        <p class="mt-2 text-slate-400">まだ同期データが届いていません。</p>
-      )}
+    <!-- 全体ランキング -->
+    <section class="mt-10 rounded-2xl bg-slate-900/60 p-5 ring-1 ring-slate-800 sm:p-6">
+      <div class="flex items-baseline justify-between">
+        <h2 class="text-lg font-bold">今月の全体ランキング</h2>
+        <p class="text-xs text-slate-500">Top 10</p>
+      </div>
+      <ol class="mt-4 divide-y divide-slate-800">
+        {overallTop.length === 0 ? (
+          <li class="py-4 text-sm text-slate-500">まだデータがありません</li>
+        ) : (
+          overallTop.map((m, i) => {
+            const h = houseById(m.house_id);
+            const lv = userLevelInfo(m.total_xp);
+            return (
+              <li class="flex items-center gap-3 py-3 text-sm">
+                <span class="w-8 text-right font-mono text-slate-500 tabular-nums">#{i + 1}</span>
+                <span class={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-base ${h?.themeBg ?? 'bg-slate-800'} ${h?.themeRing ?? 'ring-slate-700'} ring-1`}>
+                  {h?.emoji ?? '?'}
+                </span>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <span class="truncate font-medium">{m.display_name}</span>
+                    <span class={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-slate-100 ${h?.themeBar ?? 'bg-slate-700'}`}>Lv {lv.level}</span>
+                  </div>
+                  <div class="mt-1 flex items-center gap-2">
+                    <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-800">
+                      <div class={`h-full ${h?.themeBar ?? 'bg-slate-600'}`} style={`width: ${lv.progress}%`}></div>
+                    </div>
+                    <span class="shrink-0 font-mono text-[10px] text-slate-500 tabular-nums">{fmt(lv.inLevel)}/{fmt(lv.span)} XP</span>
+                  </div>
+                </div>
+                <span class="shrink-0 font-mono text-slate-300 tabular-nums">{fmt(m.points)} pt</span>
+              </li>
+            );
+          })
+        )}
+      </ol>
     </section>
+
+    <footer class="mt-12 border-t border-slate-800 pt-6 text-xs text-slate-500">
+      <p>個別の寮詳細・累積ランキング・個人ページは順次追加します（Phase 3）。</p>
+    </footer>
   </main>
 </Layout>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -154,8 +154,8 @@ function userLevelInfo(xp: number) {
 
             <div class="mt-3">
               <div class="flex items-baseline justify-between text-xs text-slate-400">
+                <span>次Lv {level + 1} まで</span>
                 <span>{fmt(s.total_xp - curXp)} / {fmt(nextXp - curXp)} XP</span>
-                <span>次Lvまで</span>
               </div>
               <div class="mt-1 h-2 overflow-hidden rounded-full bg-slate-900/70">
                 <div class={`h-full ${h.themeBar}`} style={`width: ${progress}%`}></div>

--- a/web/src/pages/leaderboard.astro
+++ b/web/src/pages/leaderboard.astro
@@ -1,0 +1,163 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { HOUSES, houseById, levelFromXp, requiredXpForLevel, USER_LEVEL_COEF, USER_LEVEL_EXP } from '../lib/houses.ts';
+
+export const prerender = false;
+
+const env = (Astro.locals as { runtime?: { env?: { DB?: D1Database } } }).runtime?.env;
+
+const url = new URL(Astro.request.url);
+const modeParam = (url.searchParams.get('mode') ?? 'monthly').toLowerCase();
+const mode: 'monthly' | 'total' = modeParam === 'total' ? 'total' : 'monthly';
+const houseFilter = url.searchParams.get('house') ?? '';
+const validHouseFilter = HOUSES.find((h) => h.id === houseFilter) ? houseFilter : '';
+
+const currentYm = new Date().toLocaleString('sv-SE', { timeZone: 'Asia/Tokyo' }).slice(0, 7);
+
+interface Row {
+  discord_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  house_id: string;
+  total_xp: number;
+  month_pt: number;
+  vc_seconds: number;
+  text_messages: number;
+}
+
+let rows: Row[] = [];
+if (env?.DB) {
+  const orderBy = mode === 'total' ? 'total_xp DESC' : 'month_pt DESC, total_xp DESC';
+  const whereHouse = validHouseFilter ? 'AND sh.house_id = ?' : '';
+  const sql = `
+    SELECT u.discord_id, u.display_name, u.avatar_url, sh.house_id,
+           COALESCE(ct.total_xp, 0)      AS total_xp,
+           COALESCE(cm.points,  0)       AS month_pt,
+           COALESCE(ct.vc_seconds, 0)    AS vc_seconds,
+           COALESCE(ct.text_messages, 0) AS text_messages
+    FROM sorting_hat sh
+    JOIN users u ON sh.discord_id = u.discord_id
+    LEFT JOIN contribution_totals  ct ON sh.discord_id = ct.discord_id
+    LEFT JOIN contribution_monthly cm ON sh.discord_id = cm.discord_id AND cm.year_month = ?
+    WHERE 1=1 ${whereHouse}
+    ORDER BY ${orderBy}
+    LIMIT 100
+  `;
+  const params: (string | number)[] = [currentYm];
+  if (validHouseFilter) params.push(validHouseFilter);
+  const result = await env.DB.prepare(sql).bind(...params).all<Row>();
+  rows = result.results ?? [];
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+function vcHM(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+function userLevelInfo(xp: number) {
+  const level = levelFromXp(xp, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const curXp = requiredXpForLevel(level, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const nextXp = requiredXpForLevel(level + 1, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  const inLv = xp - curXp;
+  const span = Math.max(1, nextXp - curXp);
+  const progress = Math.min(100, Math.max(0, (inLv / span) * 100));
+  return { level, inLv, span, progress };
+}
+
+const modeLabel = mode === 'total' ? '累積XP順' : '今月pt順';
+const valueLabelShort = mode === 'total' ? 'XP' : 'pt';
+
+function buildHref(overrides: { mode?: string; house?: string }): string {
+  const sp = new URLSearchParams();
+  const m = overrides.mode ?? mode;
+  if (m !== 'monthly') sp.set('mode', m);
+  const h = overrides.house ?? validHouseFilter;
+  if (h) sp.set('house', h);
+  const s = sp.toString();
+  return s ? `/leaderboard?${s}` : '/leaderboard';
+}
+---
+<Layout title={`ランキング (${modeLabel}) | ぱぶびゅ！ダッシュボード`}>
+  <main class="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14">
+    <nav class="mb-6 text-sm">
+      <a href="/" class="text-slate-400 hover:text-slate-200">← 寮対抗ボードへ戻る</a>
+    </nav>
+
+    <header>
+      <p class="text-xs uppercase tracking-[0.3em] text-slate-500">pubview / leaderboard</p>
+      <h1 class="text-3xl font-bold tracking-tight sm:text-4xl">🏆 個人ランキング</h1>
+      <p class="mt-1 text-sm text-slate-400">{modeLabel}・{validHouseFilter ? `${houseById(validHouseFilter)?.emoji} ${houseById(validHouseFilter)?.name} のみ` : '全寮'}・最大100名</p>
+    </header>
+
+    <!-- フィルタ切替 -->
+    <section class="mt-6 flex flex-wrap items-center gap-3 text-xs">
+      <div class="flex items-center gap-1.5">
+        <span class="text-slate-500">並び替え:</span>
+        <a href={buildHref({ mode: 'monthly' })} class={`rounded px-2.5 py-1 ${mode === 'monthly' ? 'bg-slate-700 text-slate-100' : 'bg-slate-900/60 text-slate-400 hover:text-slate-200'}`}>今月pt</a>
+        <a href={buildHref({ mode: 'total' })} class={`rounded px-2.5 py-1 ${mode === 'total' ? 'bg-slate-700 text-slate-100' : 'bg-slate-900/60 text-slate-400 hover:text-slate-200'}`}>累積XP</a>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <span class="text-slate-500">寮:</span>
+        <a href={buildHref({ house: '' })} class={`rounded px-2.5 py-1 ${!validHouseFilter ? 'bg-slate-700 text-slate-100' : 'bg-slate-900/60 text-slate-400 hover:text-slate-200'}`}>全寮</a>
+        {HOUSES.map((h) => (
+          <a href={buildHref({ house: h.id })} class={`rounded px-2.5 py-1 ${validHouseFilter === h.id ? `${h.themeBar} text-slate-100` : 'bg-slate-900/60 text-slate-400 hover:text-slate-200'}`}>
+            {h.emoji} {h.name}
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <section class="mt-6 rounded-2xl bg-slate-900/60 p-4 ring-1 ring-slate-800 sm:p-6">
+      {rows.length === 0 ? (
+        <p class="py-6 text-center text-sm text-slate-500">該当するメンバーがいません。</p>
+      ) : (
+        <ol class="divide-y divide-slate-800">
+          {rows.map((m, i) => {
+            const h = houseById(m.house_id);
+            const lv = userLevelInfo(m.total_xp);
+            const value = mode === 'total' ? m.total_xp : m.month_pt;
+            return (
+              <li class="flex items-center gap-3 py-3 text-sm">
+                <span class="w-10 text-right font-mono text-slate-500 tabular-nums">#{i + 1}</span>
+                <img
+                  src={m.avatar_url ?? '/favicon.svg'}
+                  alt=""
+                  loading="lazy"
+                  class="h-8 w-8 shrink-0 rounded-full bg-slate-800 object-cover"
+                />
+                <a href={`/houses/${m.house_id}`} class={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-base ${h?.themeBg ?? 'bg-slate-800'} ${h?.themeRing ?? 'ring-slate-700'} ring-1 hover:ring-2`} title={h?.name ?? ''}>
+                  {h?.emoji ?? '?'}
+                </a>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <a href={`/u/${encodeURIComponent(m.display_name)}`} class="truncate font-medium hover:underline">{m.display_name}</a>
+                    <span class={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-slate-100 ${h?.themeBar ?? 'bg-slate-700'}`}>Lv {lv.level}</span>
+                  </div>
+                  <div class="mt-1 flex items-center gap-2">
+                    <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-800">
+                      <div class={`h-full ${h?.themeBar ?? 'bg-slate-600'}`} style={`width: ${lv.progress}%`}></div>
+                    </div>
+                    <span class="shrink-0 font-mono text-[10px] text-slate-500 tabular-nums">
+                      {fmt(lv.inLv)}/{fmt(lv.span)} XP
+                    </span>
+                  </div>
+                </div>
+                <div class="shrink-0 text-right">
+                  <div class="font-mono text-slate-200 tabular-nums">{fmt(value)} {valueLabelShort}</div>
+                  <div class="text-[10px] text-slate-500 tabular-nums">VC {vcHM(m.vc_seconds)} ・ {fmt(m.text_messages)}件</div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+
+    <footer class="mt-8 text-center text-xs text-slate-500">
+      <a href="/" class="hover:text-slate-300">← トップへ戻る</a>
+    </footer>
+  </main>
+</Layout>

--- a/web/src/pages/monthly/[yyyy_mm].astro
+++ b/web/src/pages/monthly/[yyyy_mm].astro
@@ -1,0 +1,189 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { HOUSES, houseById, levelFromXp, requiredXpForLevel, USER_LEVEL_COEF, USER_LEVEL_EXP } from '../../lib/houses.ts';
+
+export const prerender = false;
+
+const env = (Astro.locals as { runtime?: { env?: { DB?: D1Database } } }).runtime?.env;
+
+const ym = Astro.params.yyyy_mm ?? '';
+if (!/^\d{4}-\d{2}$/.test(ym)) {
+  return new Response('Invalid year_month (expected YYYY-MM)', { status: 400 });
+}
+
+interface HouseAgg {
+  house_id: string;
+  pt: number;
+  members: number;
+}
+interface UserMonth {
+  discord_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  house_id: string;
+  total_xp: number;
+  points: number;
+  vc_seconds: number;
+  text_messages: number;
+}
+
+let houseAggs: HouseAgg[] = [];
+let topUsers: UserMonth[] = [];
+
+if (env?.DB) {
+  // 寮別合計
+  const r1 = await env.DB.prepare(
+    `SELECT sh.house_id,
+            COALESCE(SUM(m.points), 0) AS pt,
+            COUNT(DISTINCT sh.discord_id) AS members
+     FROM sorting_hat sh
+     LEFT JOIN contribution_monthly m ON sh.discord_id = m.discord_id AND m.year_month = ?
+     GROUP BY sh.house_id
+     ORDER BY pt DESC`,
+  ).bind(ym).all<HouseAgg>();
+  houseAggs = r1.results ?? [];
+  // 4寮全部出すため、欠けてる寮を埋める
+  for (const h of HOUSES) {
+    if (!houseAggs.find((a) => a.house_id === h.id)) {
+      houseAggs.push({ house_id: h.id, pt: 0, members: 0 });
+    }
+  }
+  houseAggs.sort((a, b) => b.pt - a.pt || a.house_id.localeCompare(b.house_id));
+
+  // 個人MVP Top 20
+  const r2 = await env.DB.prepare(
+    `SELECT u.discord_id, u.display_name, u.avatar_url, sh.house_id,
+            COALESCE(ct.total_xp, 0) AS total_xp,
+            m.points AS points,
+            m.vc_seconds AS vc_seconds,
+            m.text_messages AS text_messages
+     FROM contribution_monthly m
+     JOIN users u ON m.discord_id = u.discord_id
+     JOIN sorting_hat sh ON m.discord_id = sh.discord_id
+     LEFT JOIN contribution_totals ct ON m.discord_id = ct.discord_id
+     WHERE m.year_month = ?
+     ORDER BY m.points DESC, ct.total_xp DESC
+     LIMIT 20`,
+  ).bind(ym).all<UserMonth>();
+  topUsers = r2.results ?? [];
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+function vcHM(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+function userLevelInfo(xp: number) {
+  const level = levelFromXp(xp, USER_LEVEL_COEF, USER_LEVEL_EXP);
+  return { level };
+}
+
+const medals = ['🥇', '🥈', '🥉'];
+const totalHousePt = houseAggs.reduce((s, a) => s + a.pt, 0);
+
+// 前月・翌月リンク
+function shiftMonth(ym: string, delta: number): string {
+  const [yy, mm] = ym.split('-').map(Number);
+  const d = new Date(yy, mm - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+const prevYm = shiftMonth(ym, -1);
+const nextYm = shiftMonth(ym, +1);
+const currentYm = new Date().toLocaleString('sv-SE', { timeZone: 'Asia/Tokyo' }).slice(0, 7);
+const isFutureMonth = ym > currentYm;
+---
+<Layout title={`${ym} 月次アーカイブ | ぱぶびゅ！ダッシュボード`}>
+  <main class="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14">
+    <nav class="mb-6 flex items-center justify-between text-sm">
+      <a href="/" class="text-slate-400 hover:text-slate-200">← 寮対抗ボードへ戻る</a>
+      <div class="flex items-center gap-2 text-xs">
+        <a href={`/monthly/${prevYm}`} class="rounded bg-slate-800 px-2 py-1 text-slate-300 hover:bg-slate-700">← {prevYm}</a>
+        {!isFutureMonth && (
+          <a href={`/monthly/${nextYm}`} class="rounded bg-slate-800 px-2 py-1 text-slate-300 hover:bg-slate-700">{nextYm} →</a>
+        )}
+      </div>
+    </nav>
+
+    <header>
+      <p class="text-xs uppercase tracking-[0.3em] text-slate-500">pubview / monthly archive</p>
+      <h1 class="text-3xl font-black tracking-tight sm:text-4xl">📅 {ym} 月次アーカイブ</h1>
+      {ym === currentYm && <p class="mt-1 text-xs text-slate-400">（進行中の今月）</p>}
+    </header>
+
+    <section class="mt-8">
+      <h2 class="text-lg font-bold">🏰 寮対抗ランキング</h2>
+      <ol class="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {houseAggs.map((agg, i) => {
+          const h = houseById(agg.house_id);
+          if (!h) return null;
+          const medal = medals[i] ?? `${i + 1}.`;
+          const share = totalHousePt > 0 ? (agg.pt / totalHousePt * 100) : 0;
+          return (
+            <a href={`/houses/${agg.house_id}`} class={`block rounded-2xl ${h.themeBg} p-4 ring-1 ${h.themeRing} hover:ring-2`}>
+              <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                  <span class="text-2xl">{medal}</span>
+                  <div>
+                    <div class="text-3xl leading-none">{h.emoji}</div>
+                    <div class={`mt-1 text-lg font-bold ${h.themeAccent}`}>{h.name}</div>
+                  </div>
+                </div>
+                <div class="text-right">
+                  <div class="text-xs text-slate-300">月次pt</div>
+                  <div class="text-2xl font-black tabular-nums">{fmt(agg.pt)}</div>
+                  <div class="mt-0.5 text-[10px] text-slate-400">{agg.members}人 ・ {share.toFixed(1)}%</div>
+                </div>
+              </div>
+            </a>
+          );
+        })}
+      </ol>
+    </section>
+
+    <section class="mt-10 rounded-2xl bg-slate-900/60 p-5 ring-1 ring-slate-800 sm:p-6">
+      <div class="flex items-baseline justify-between">
+        <h2 class="text-lg font-bold">🌟 個人MVP（{ym} の月次pt順）</h2>
+        <p class="text-xs text-slate-500">Top {topUsers.length}</p>
+      </div>
+      {topUsers.length === 0 ? (
+        <p class="mt-6 text-sm text-slate-500">この月の記録はありません。</p>
+      ) : (
+        <ol class="mt-4 divide-y divide-slate-800">
+          {topUsers.map((m, i) => {
+            const h = houseById(m.house_id);
+            const lv = userLevelInfo(m.total_xp);
+            return (
+              <li class="flex items-center gap-3 py-3 text-sm">
+                <span class="w-10 text-right font-mono text-slate-500 tabular-nums">#{i + 1}</span>
+                <img
+                  src={m.avatar_url ?? '/favicon.svg'}
+                  alt=""
+                  loading="lazy"
+                  class="h-8 w-8 shrink-0 rounded-full bg-slate-800 object-cover"
+                />
+                <a href={`/houses/${m.house_id}`} class={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-base ${h?.themeBg ?? 'bg-slate-800'} ${h?.themeRing ?? 'ring-slate-700'} ring-1 hover:ring-2`} title={h?.name ?? ''}>
+                  {h?.emoji ?? '?'}
+                </a>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <a href={`/u/${encodeURIComponent(m.display_name)}`} class="truncate font-medium hover:underline">{m.display_name}</a>
+                    <span class={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-slate-100 ${h?.themeBar ?? 'bg-slate-700'}`}>Lv {lv.level}</span>
+                  </div>
+                  <div class="mt-0.5 text-[10px] text-slate-500 tabular-nums">VC {vcHM(m.vc_seconds)} ・ {fmt(m.text_messages)}件</div>
+                </div>
+                <span class="shrink-0 font-mono text-slate-300 tabular-nums">{fmt(m.points)} pt</span>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+
+    <footer class="mt-10 border-t border-slate-800 pt-6 text-xs text-slate-500">
+      <a href="/leaderboard" class="hover:text-slate-300">全体ランキング →</a>
+    </footer>
+  </main>
+</Layout>

--- a/web/src/pages/u/[slug].astro
+++ b/web/src/pages/u/[slug].astro
@@ -1,0 +1,222 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { houseById, levelFromXp, requiredXpForLevel, USER_LEVEL_COEF, USER_LEVEL_EXP } from '../../lib/houses.ts';
+
+export const prerender = false;
+
+const env = (Astro.locals as { runtime?: { env?: { DB?: D1Database } } }).runtime?.env;
+
+const slug = decodeURIComponent(Astro.params.slug ?? '');
+if (!slug) {
+  return new Response('User not found', { status: 404 });
+}
+
+interface UserData {
+  discord_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  house_id: string | null;
+  total_xp: number;
+  vc_seconds: number;
+  text_messages: number;
+}
+interface MonthlyRow {
+  year_month: string;
+  points: number;
+  vc_seconds: number;
+  text_messages: number;
+}
+
+let user: UserData | null = null;
+let monthlyHistory: MonthlyRow[] = [];
+let overallRank: number | null = null;
+let houseRank: number | null = null;
+let houseMemberCount: number = 0;
+
+if (env?.DB) {
+  // 1) ユーザー基本情報 + 所属寮 + 累積
+  const u = await env.DB.prepare(
+    `SELECT u.discord_id, u.display_name, u.avatar_url,
+            sh.house_id,
+            COALESCE(ct.total_xp, 0)      AS total_xp,
+            COALESCE(ct.vc_seconds, 0)    AS vc_seconds,
+            COALESCE(ct.text_messages, 0) AS text_messages
+     FROM users u
+     LEFT JOIN sorting_hat sh ON u.discord_id = sh.discord_id
+     LEFT JOIN contribution_totals ct ON u.discord_id = ct.discord_id
+     WHERE u.display_name = ?
+     LIMIT 1`,
+  ).bind(slug).first<UserData>();
+  user = u ?? null;
+
+  if (user) {
+    // 2) 月別履歴（直近12ヶ月）
+    const m = await env.DB.prepare(
+      `SELECT year_month, points, vc_seconds, text_messages
+       FROM contribution_monthly
+       WHERE discord_id = ?
+       ORDER BY year_month DESC
+       LIMIT 12`,
+    ).bind(user.discord_id).all<MonthlyRow>();
+    monthlyHistory = m.results ?? [];
+
+    // 3) 全体ランク（累積XP順）
+    const allRank = await env.DB.prepare(
+      `SELECT 1 + COUNT(*) AS rk
+       FROM sorting_hat s
+       JOIN contribution_totals ct ON s.discord_id = ct.discord_id
+       WHERE ct.total_xp > ?`,
+    ).bind(user.total_xp).first<{ rk: number }>();
+    overallRank = allRank?.rk ?? null;
+
+    // 4) 寮内ランク + 寮メンバー数
+    if (user.house_id) {
+      const hr = await env.DB.prepare(
+        `SELECT 1 + COUNT(*) AS rk
+         FROM sorting_hat s
+         JOIN contribution_totals ct ON s.discord_id = ct.discord_id
+         WHERE s.house_id = ? AND ct.total_xp > ?`,
+      ).bind(user.house_id, user.total_xp).first<{ rk: number }>();
+      houseRank = hr?.rk ?? null;
+
+      const hc = await env.DB.prepare(
+        `SELECT COUNT(*) AS cnt FROM sorting_hat WHERE house_id = ?`,
+      ).bind(user.house_id).first<{ cnt: number }>();
+      houseMemberCount = hc?.cnt ?? 0;
+    }
+  }
+}
+
+if (!user) {
+  return new Response(`User "${slug}" not found`, { status: 404 });
+}
+
+const houseDef = user.house_id ? houseById(user.house_id) : undefined;
+const lv = levelFromXp(user.total_xp, USER_LEVEL_COEF, USER_LEVEL_EXP);
+const curXp = requiredXpForLevel(lv, USER_LEVEL_COEF, USER_LEVEL_EXP);
+const nextXp = requiredXpForLevel(lv + 1, USER_LEVEL_COEF, USER_LEVEL_EXP);
+const inLv = user.total_xp - curXp;
+const span = Math.max(1, nextXp - curXp);
+const progress = Math.min(100, Math.max(0, (inLv / span) * 100));
+
+const currentYm = new Date().toLocaleString('sv-SE', { timeZone: 'Asia/Tokyo' }).slice(0, 7);
+const currentMonth = monthlyHistory.find((m) => m.year_month === currentYm);
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+function vcHM(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+---
+<Layout title={`${user.display_name} | ぱぶびゅ！ダッシュボード`}>
+  <main class="mx-auto max-w-3xl px-4 py-10 sm:px-6 sm:py-14">
+    <nav class="mb-6 text-sm">
+      <a href="/" class="text-slate-400 hover:text-slate-200">← 寮対抗ボードへ戻る</a>
+    </nav>
+
+    <header class="rounded-2xl bg-slate-900/60 p-6 ring-1 ring-slate-800 sm:p-8">
+      <div class="flex flex-col items-center gap-4 sm:flex-row sm:items-end sm:gap-6">
+        <img
+          src={user.avatar_url ?? '/favicon.svg'}
+          alt=""
+          class="h-24 w-24 rounded-full bg-slate-800 object-cover ring-2 ring-slate-700"
+        />
+        <div class="flex-1 text-center sm:text-left">
+          <h1 class="text-2xl font-black tracking-tight sm:text-3xl">{user.display_name}</h1>
+          {houseDef ? (
+            <a href={`/houses/${houseDef.id}`} class={`mt-1 inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-semibold ${houseDef.themeBg} ${houseDef.themeAccent} ring-1 ${houseDef.themeRing}`}>
+              {houseDef.emoji} {houseDef.name}
+            </a>
+          ) : (
+            <span class="mt-1 inline-block text-xs text-slate-500">未組分け</span>
+          )}
+        </div>
+        <div class="text-center sm:text-right">
+          <div class="text-xs text-slate-400">個人レベル</div>
+          <div class="text-5xl font-black tabular-nums">{lv}</div>
+        </div>
+      </div>
+
+      <div class="mt-5">
+        <div class="flex items-baseline justify-between text-xs text-slate-300">
+          <span>{fmt(inLv)} / {fmt(span)} XP</span>
+          <span>次Lv {lv + 1} まで</span>
+        </div>
+        <div class="mt-1 h-2.5 overflow-hidden rounded-full bg-slate-900/70">
+          <div class={`h-full ${houseDef?.themeBar ?? 'bg-slate-600'}`} style={`width: ${progress}%`}></div>
+        </div>
+      </div>
+    </header>
+
+    <section class="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">累積XP</div>
+        <div class="mt-1 text-xl font-bold tabular-nums">{fmt(user.total_xp)}</div>
+      </div>
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">今月pt</div>
+        <div class="mt-1 text-xl font-bold tabular-nums">{fmt(currentMonth?.points ?? 0)}</div>
+      </div>
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">累積VC</div>
+        <div class="mt-1 text-xl font-bold tabular-nums">{vcHM(user.vc_seconds)}</div>
+      </div>
+      <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+        <div class="text-xs text-slate-400">累積投稿</div>
+        <div class="mt-1 text-xl font-bold tabular-nums">{fmt(user.text_messages)}</div>
+      </div>
+    </section>
+
+    {(overallRank !== null || houseRank !== null) && (
+      <section class="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {overallRank !== null && (
+          <div class="rounded-xl bg-slate-900/60 p-4 ring-1 ring-slate-800">
+            <div class="text-xs text-slate-400">全体ランク（累積XP順）</div>
+            <div class="mt-1 text-2xl font-bold tabular-nums">#{overallRank}</div>
+          </div>
+        )}
+        {houseRank !== null && houseDef && (
+          <div class={`rounded-xl ${houseDef.themeBg} p-4 ring-1 ${houseDef.themeRing}`}>
+            <div class="text-xs text-slate-300">{houseDef.emoji} {houseDef.name} 内ランク</div>
+            <div class={`mt-1 text-2xl font-bold tabular-nums ${houseDef.themeAccent}`}>#{houseRank} / {houseMemberCount}人</div>
+          </div>
+        )}
+      </section>
+    )}
+
+    <section class="mt-8 rounded-2xl bg-slate-900/60 p-5 ring-1 ring-slate-800 sm:p-6">
+      <h2 class="text-lg font-bold">月別履歴</h2>
+      {monthlyHistory.length === 0 ? (
+        <p class="mt-3 text-sm text-slate-500">まだ記録がありません。</p>
+      ) : (
+        <table class="mt-4 w-full text-sm">
+          <thead class="text-xs uppercase tracking-wider text-slate-500">
+            <tr>
+              <th class="py-2 text-left font-normal">年月</th>
+              <th class="py-2 text-right font-normal">pt</th>
+              <th class="py-2 text-right font-normal">VC</th>
+              <th class="py-2 text-right font-normal">投稿</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-800">
+            {monthlyHistory.map((m) => (
+              <tr>
+                <td class="py-2.5 font-mono">{m.year_month}{m.year_month === currentYm ? <span class="ml-2 rounded bg-slate-700 px-1.5 py-0.5 text-[10px] font-normal text-slate-200">今月</span> : ''}</td>
+                <td class="py-2.5 text-right font-mono tabular-nums">{fmt(m.points)}</td>
+                <td class="py-2.5 text-right font-mono tabular-nums">{vcHM(m.vc_seconds)}</td>
+                <td class="py-2.5 text-right font-mono tabular-nums">{fmt(m.text_messages)}件</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+
+    <footer class="mt-8 text-center text-xs text-slate-500">
+      <a href="/leaderboard" class="hover:text-slate-300">全体ランキングへ →</a>
+    </footer>
+  </main>
+</Layout>

--- a/web/src/pages/u/[slug].astro
+++ b/web/src/pages/u/[slug].astro
@@ -26,9 +26,16 @@ interface MonthlyRow {
   vc_seconds: number;
   text_messages: number;
 }
+interface DailySnapshotRow {
+  snapshot_date: string;
+  total_xp: number;
+  vc_seconds: number;
+  text_messages: number;
+}
 
 let user: UserData | null = null;
 let monthlyHistory: MonthlyRow[] = [];
+let dailySnapshots: DailySnapshotRow[] = [];
 let overallRank: number | null = null;
 let houseRank: number | null = null;
 let houseMemberCount: number = 0;
@@ -59,6 +66,16 @@ if (env?.DB) {
        LIMIT 12`,
     ).bind(user.discord_id).all<MonthlyRow>();
     monthlyHistory = m.results ?? [];
+
+    // 2.5) 日次スナップショット（直近31日 + 当日比較用に少し多めで取得、後でclient側で diff 計算）
+    const ds = await env.DB.prepare(
+      `SELECT snapshot_date, total_xp, vc_seconds, text_messages
+       FROM daily_snapshots
+       WHERE discord_id = ?
+       ORDER BY snapshot_date DESC
+       LIMIT 35`,
+    ).bind(user.discord_id).all<DailySnapshotRow>();
+    dailySnapshots = (ds.results ?? []).slice().reverse(); // 古い順
 
     // 3) 全体ランク（累積XP順）
     const allRank = await env.DB.prepare(
@@ -109,6 +126,39 @@ function vcHM(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   return `${h}h ${m}m`;
+}
+
+// 日次グラフ用データ: 連続した日付の系列を生成し、各日の獲得XP(=当日total_xp - 前日total_xp)を計算
+interface DailyPoint {
+  date: string;        // YYYY-MM-DD
+  label: string;       // M/D
+  gainedXp: number;
+  cumulativeXp: number;
+}
+function buildDailyChart(snapshots: DailySnapshotRow[], currentTotalXp: number, days: number = 30): DailyPoint[] {
+  const tzDate = new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
+  const byDate = new Map<string, DailySnapshotRow>();
+  for (const s of snapshots) byDate.set(s.snapshot_date, s);
+  // 直近 days+1 日分の系列（前日比較で初日が0になる分1日多く取る）
+  const points: DailyPoint[] = [];
+  let prevTotal = 0;
+  for (let i = days; i >= 0; i--) {
+    const d = new Date(tzDate.getTime() - i * 24 * 60 * 60 * 1000);
+    const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const label = `${d.getMonth() + 1}/${d.getDate()}`;
+    const row = byDate.get(iso);
+    // 「今日(=i==0)」は現在の累積XPを使い、進行中の獲得分も反映
+    let cumulative: number;
+    if (i === 0) {
+      cumulative = currentTotalXp;
+    } else {
+      cumulative = row ? row.total_xp : prevTotal;
+    }
+    const gained = Math.max(0, cumulative - prevTotal);
+    points.push({ date: iso, label, gainedXp: gained, cumulativeXp: cumulative });
+    prevTotal = cumulative;
+  }
+  return points.slice(1); // 基準点を捨てる
 }
 ---
 <Layout title={`${user.display_name} | ぱぶびゅ！ダッシュボード`}>
@@ -186,6 +236,83 @@ function vcHM(seconds: number): string {
         )}
       </section>
     )}
+
+    {(() => {
+      const points = buildDailyChart(dailySnapshots, user.total_xp, 30);
+      const maxGain = Math.max(1, ...points.map((p) => p.gainedXp));
+      const totalGain30d = points.reduce((s, p) => s + p.gainedXp, 0);
+      const chartW = 600;
+      const chartH = 140;
+      const padTop = 8;
+      const padBottom = 22;
+      const barAreaH = chartH - padTop - padBottom;
+      const barW = chartW / points.length;
+      const accent = houseDef?.themeBar?.replace('bg-', '') ?? 'slate-500';
+      const accentColor = {
+        'raptor': '#3FA34D',
+        'krug':   '#A0522D',
+        'wolf':   '#5B7C99',
+        'gromp':  '#7A5FA8',
+      }[houseDef?.id ?? ''] ?? '#64748b';
+      return (
+        <section class="mt-8 rounded-2xl bg-slate-900/60 p-5 ring-1 ring-slate-800 sm:p-6">
+          <div class="flex items-baseline justify-between">
+            <h2 class="text-lg font-bold">📈 日次成果（過去30日）</h2>
+            <p class="text-xs text-slate-500">
+              直近30日: <span class="font-mono tabular-nums text-slate-300">+{fmt(totalGain30d)} XP</span>
+            </p>
+          </div>
+          {totalGain30d === 0 ? (
+            <p class="mt-6 text-sm text-slate-500">この30日間の獲得XPはまだありません。テキスト投稿やVC在室で貯まり始めます。</p>
+          ) : (
+            <div class="mt-4 overflow-x-auto">
+              <svg viewBox={`0 0 ${chartW} ${chartH}`} preserveAspectRatio="none" class="h-36 w-full">
+                {points.map((p, i) => {
+                  const h = (p.gainedXp / maxGain) * barAreaH;
+                  const x = i * barW + 1;
+                  const y = padTop + (barAreaH - h);
+                  return (
+                    <g>
+                      <rect
+                        x={x}
+                        y={y}
+                        width={Math.max(1, barW - 2)}
+                        height={Math.max(h, p.gainedXp > 0 ? 1 : 0)}
+                        fill={accentColor}
+                        opacity={p.gainedXp > 0 ? 0.9 : 0.15}
+                        rx="1"
+                      >
+                        <title>{`${p.date}: +${p.gainedXp.toLocaleString()} XP (累積 ${p.cumulativeXp.toLocaleString()})`}</title>
+                      </rect>
+                      {/* 5日ごと + 最終日に日付ラベル */}
+                      {(i % 5 === 0 || i === points.length - 1) && (
+                        <text
+                          x={x + barW / 2}
+                          y={chartH - 6}
+                          text-anchor="middle"
+                          font-size="9"
+                          fill="#64748b"
+                          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+                        >
+                          {p.label}
+                        </text>
+                      )}
+                    </g>
+                  );
+                })}
+                {/* 上部最大値ラベル */}
+                <text x="2" y={padTop + 8} font-size="9" fill="#475569" font-family="ui-monospace">
+                  最大 {fmt(maxGain)} XP
+                </text>
+              </svg>
+            </div>
+          )}
+          <p class="mt-2 text-[10px] text-slate-500">
+            ※ バーにカーソルを乗せると詳細表示。今日のバーは進行中。
+          </p>
+        </section>
+      );
+    })()}
 
     <section class="mt-8 rounded-2xl bg-slate-900/60 p-5 ring-1 ring-slate-800 sm:p-6">
       <h2 class="text-lg font-bold">月別履歴</h2>

--- a/web/src/pages/u/[slug].astro
+++ b/web/src/pages/u/[slug].astro
@@ -192,8 +192,8 @@ function buildDailyChart(snapshots: DailySnapshotRow[], currentTotalXp: number, 
 
       <div class="mt-5">
         <div class="flex items-baseline justify-between text-xs text-slate-300">
-          <span>{fmt(inLv)} / {fmt(span)} XP</span>
           <span>次Lv {lv + 1} まで</span>
+          <span>{fmt(inLv)} / {fmt(span)} XP</span>
         </div>
         <div class="mt-1 h-2.5 overflow-hidden rounded-full bg-slate-900/70">
           <div class={`h-full ${houseDef?.themeBar ?? 'bg-slate-600'}`} style={`width: ${progress}%`}></div>

--- a/web/tailwind.config.mjs
+++ b/web/tailwind.config.mjs
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx,md,mdx,svelte,vue}'],
+  theme: {
+    extend: {
+      colors: {
+        // 寮テーマカラー（LoLジャングルキャンプ準拠）
+        raptor: { DEFAULT: '#3FA34D', dark: '#1F5A2A' },
+        krug:   { DEFAULT: '#A0522D', dark: '#5B2E18' },
+        wolf:   { DEFAULT: '#5B7C99', dark: '#324A60' },
+        gromp:  { DEFAULT: '#7A5FA8', dark: '#46356A' },
+      },
+    },
+  },
+  plugins: [],
+};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  }
+}

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -1,0 +1,13 @@
+name = "pubview-dashboard"
+compatibility_date = "2026-05-01"
+compatibility_flags = ["nodejs_compat"]
+pages_build_output_dir = "./dist"
+
+# D1: Bot から同期したコントリビューションデータを保持
+[[d1_databases]]
+binding = "DB"
+database_name = "pubview-dashboard-db"
+database_id = "c7842d1c-8e22-47fd-a823-e53c9b095021"
+
+# シークレットは wrangler secret put で登録（リポジトリに含めない）:
+#   wrangler pages secret put INGEST_TOKEN --project-name pubview-dashboard


### PR DESCRIPTION
## リリース概要

ぱぶびゅ！コントリビューションシステムをフルスタックで導入する統合PR。Discord Bot側のXP計測〜寮機能〜自動投稿〜Cloudflare D1同期、Web側の5画面ダッシュボード（個人成果グラフ含む）まで一気通貫。

**動作確認チェックリスト**: [#32](https://github.com/New-Meta-Inc/pubview_bot/issues/32)（全Phaseのテスト観点 + スクショ証跡 [test-evidence ブランチ](https://github.com/New-Meta-Inc/pubview_bot/tree/test-evidence)）

旧 PR #29 #30 は本ブランチに統合済み（クローズ済み）。

## コミット構成（古い順）

| Phase | Commit | 内容 |
|---|---|---|
| **1** | `1b70c5b` | コントリビューション計測の基盤（VC/text/DB/`/score`） |
| **3-1** | `beb4078` | Webダッシュボード雛形（Astro/Tailwind/Cloudflare Pages + D1 + `/api/ingest`） |
| **3-1.5** | `7d9ddbd` | 寮長表示・寮トップ5化・個人レベルUI（migration 0002） |
| **2-A** | `d6c372d` | `/setup_house_channels` admin（4寮ぶんのカテゴリ・雑談・リーダーボード・VC一括作成） |
| **2-B** | `af7cdcf` | `/leaderboard` + `/house_standings` スラッシュコマンド |
| **2-C** | `b380758` | Lvアップ祝福通知 + `/setup_dev_channel` + `/debug_grant_xp` |
| **2-D** | `1dffae5` | 週次寮ダイジェスト + 月次サマリ自動投稿 + `weekly_snapshots` + デバッグ3コマンド |
| **3-2** | `6173167` | Bot→D1 5分同期 + `/set_house_leader` + `/clear_house_leader` + `house_leaders` |
| **3-5** | `9beb3b3` | Web5画面（houses/leaderboard/u/monthly + index navリンク） |
| 改修 | `c5e4b5e` | embed内ダッシュボードURLをクリック可能に（Lvup/週次/月次/2スラッシュ） |
| 拡張 | `3174266` | 個人ページに日次成果グラフ（過去30日）+ `daily_snapshots`（migration 0003） |

## 差分サイズ

```
 .gitignore                              |   15 +
 main.py                                 | 1515 ++++++++(変更)
 web/                                    | 6688 ++++(新規22ファイル)
 22 files changed, 8203 insertions(+), 1 deletion(-)
```

## 機能一覧

### 🤖 Bot（main.py）

#### スラッシュコマンド
- **`/score`**（全員）: 自分の所属寮・Lv・累積XP・次Lv残・今月pt・累積VC/投稿
- **`/leaderboard [mode]`**（全員）: 個人Top10（monthly/total切替、embedのURLクリッカブル）
- **`/house_standings`**（全員）: 4寮の対抗状況をembed
- **`/setup_house_channels`**（admin）: 4寮ぶんのカテゴリ＋3チャンネル一括作成（@everyone deny / 寮ロールallow / リーダーボードはBot のみpost可、idempotent）
- **`/setup_dev_channel`**（admin）: 実行者とBotのみ閲覧可能なテスト用チャンネル作成
- **`/set_house_leader [house] [user]`** / **`/clear_house_leader [house]`**（admin）: 寮長任命/解除
- **デバッグ用**: `/debug_grant_xp`、`/debug_post_weekly_digest`、`/debug_post_monthly_summary`、`/debug_save_weekly_snapshot`、`/debug_save_daily_snapshot`、`/debug_force_sync`

#### イベントフック
- `on_message`: 60秒CDで `text_messages` 加算 + Lvアップ通知
- `on_voice_state_update`: VC join/leave/move を捕捉、`vc_sessions` 管理 + Lvアップ通知
- `on_ready` 拡張: VC在室メンバー再登録、当日の日次snapshot bootstrap、全タスクstart

#### バックグラウンドタスク
- `weekly_digest_task`: 毎日10:00 JST → 月曜のみ実投稿（各寮のリーダーボード）
- `monthly_summary_task`: 毎日0:00 JST → 1日のみ実投稿（NOTIFICATION_CHANNEL_ID）
- `daily_snapshot_task`: 毎日0:00 JST 発火（日次成果グラフ用）
- `sync_to_d1_task`: 5分おきBot→D1全件同期（直近60日の日次snapshotも含む）

#### 自動投稿
- **Lvアップ祝福**（個人メンション + 寮 + 次Lvまで + 個人ページURLクリッカブル） → 所属寮の リーダーボード
- **週次寮ダイジェスト**（KPI + トップ5 + 先週比 + 4寮順位 + 寮ページURL） → 各寮 リーダーボード（月曜10:00）
- **月次サマリ**（寮対抗🥇🥈🥉 + 個人MVP Top5 + 月次ページURL） → NOTIFICATION_CHANNEL_ID（月初0:00）

#### DBテーブル追加（Bot SQLite）
- `contribution_totals` / `contribution_monthly` / `vc_sessions` / `weekly_snapshots` / `daily_snapshots` / `house_channels` / `house_leaders`

### 🌐 Web（Cloudflare Pages + D1）

#### 画面
- **`/`** 寮対抗ボード（4寮カード + 全体Top10、寮カードと名前は全てクリック可）
- **`/houses/[house_id]`** 寮詳細（KPI 4枚・XPバー・寮長・メンバー一覧表）
- **`/leaderboard?mode=monthly|total&house=...`** 全体ランキング最大100名、フィルタ・切替UI
- **`/u/[slug]`** 個人ページ（アバター・所属・Lv大表示・全体&寮内ランク・**日次成果SVGバーチャート過去30日**・月別履歴）
- **`/monthly/[yyyy-mm]`** 月次アーカイブ（4寮グリッド + 個人MVP Top20、前月/翌月ナビ）

#### API
- **`POST /api/ingest`** Bearer認証付きの同期受信。users / sorting_hat / contribution_totals / contribution_monthly / house_leaders / daily_snapshots を upsert

#### インフラ（既存・本PRで参照のみ、リソース自体は事前作成）
- D1: `pubview-dashboard-db`（7テーブル / migrations 0001-0003）
- Pages: `pubview-dashboard` → https://pubview-dashboard.pages.dev/
- Secret: `INGEST_TOKEN`（Bot ↔ Worker 共有）
- `robots.txt` で noindex（パブリックだが検索拒否）

#### UI機能
- Lv バッジ＋XPプログレスバー（寮テーマカラー: 🦖緑 / 🪨茶 / 🐺青 / 🐸紫）
- アバター画像表示（Bot 同期される `avatar_url`）
- 全名前 → 個人ページ、寮絵文字 → 寮ページ、相互リンク完備
- 「寮長: 未任命」のフォールバック表示
- 日次SVG棒グラフ（寮テーマ色、ホバーで`<title>`ツールチップ、今日のバーは進行中分も反映）
- レスポンシブレイアウト

## 設計上のポイント

| 項目 | 設計 |
|---|---|
| ポイント計算 | VC: **1pt/分**（AFK含む） / テキスト: **2pt/件**（60秒CD） |
| 個人レベル式 | 必要累積XP = **20 × N²**（Lv50 ≈ 50,000 XP） |
| 寮レベル式 | 必要累積XP = **300 × N²**（特典付与の長期目標） |
| 二重カウンタ | 累積XP（永続）+ 月次pt（年月キーで自然リセット） |
| 組分け要件 | **組分け済みのみ加算**（組分け帽子インセンティブ化） |
| 通知範囲 | `@everyone` mention 一切なし、個人メンション + 寮メンバー閲覧の権限設計 |
| 同期 | Bot→D1 5分おき全件 upsert、リアルタイム性が必要なら `/debug_force_sync` |
| クリッカブルリンク | embed.url（タイトル）+ 末尾フィールドの markdown `[📊 →](URL)` |

## 検証フロー（各Phaseごと）

1. Phaseコミットpush
2. Bot変更があれば macmini デプロイ（HANDOVER.md 手順）
3. Web変更があれば Cloudflare Pages デプロイ
4. ぱぶびゅ！Discord で動作確認 + スクショ
5. 全Phase OKならこのPRをマージ

## 本番リソース（稼働中）

- Cloudflare Pages: https://pubview-dashboard.pages.dev/
- D1 Database: `pubview-dashboard-db`
- Bot: macmini Docker、5分おきD1同期 & 日次スナップショット稼働中
- Discord 構造: 4寮ぶんのカテゴリ・チャンネル設定済、寮長4名任命済

## 環境変数追加（macmini）

```bash
-e CLOUDFLARE_INGEST_URL='https://pubview-dashboard.pages.dev/api/ingest'
-e INGEST_TOKEN='<see ~/.config/pubview/cloudflare.env>'
```

## 詳細チェックリスト

→ [Issue #32](https://github.com/New-Meta-Inc/pubview_bot/issues/32) で全観点のテスト結果＋スクショ証跡を確認可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)